### PR TITLE
Using full cert chain over single certificate

### DIFF
--- a/acme/src/main/java/io/micronaut/acme/events/CertificateEvent.java
+++ b/acme/src/main/java/io/micronaut/acme/events/CertificateEvent.java
@@ -22,7 +22,6 @@ import java.security.cert.X509Certificate;
  * Event used to alert when a new ACME certificate is ready for use.
  */
 public class CertificateEvent {
-    private final X509Certificate certificate;
     private final KeyPair domainKeyPair;
     private final X509Certificate[] fullCertificateChain;
     private boolean validationCert;
@@ -34,7 +33,6 @@ public class CertificateEvent {
      * @param validationCert if this certificate is to be used for tls-apln-01 account validation
      */
     public CertificateEvent(X509Certificate certificate, KeyPair domainKeyPair, boolean validationCert) {
-        this.certificate = certificate;
         this.domainKeyPair = domainKeyPair;
         this.validationCert = validationCert;
         this.fullCertificateChain = new X509Certificate[]{certificate};
@@ -43,7 +41,6 @@ public class CertificateEvent {
     public CertificateEvent(KeyPair domainKeyPair, X509Certificate... fullCertificateChain) {
         this.validationCert = false;
         this.domainKeyPair = domainKeyPair;
-        this.certificate = fullCertificateChain[0];
         this.fullCertificateChain = fullCertificateChain;
     }
 
@@ -51,7 +48,7 @@ public class CertificateEvent {
      * @return Certificate created by ACME server
      */
     public X509Certificate getCert() {
-        return certificate;
+        return fullCertificateChain[0];
     }
 
     /**

--- a/acme/src/main/java/io/micronaut/acme/events/CertificateEvent.java
+++ b/acme/src/main/java/io/micronaut/acme/events/CertificateEvent.java
@@ -42,7 +42,7 @@ public class CertificateEvent {
     }
 
     /**
-     * Creates a new CertificateEvent containing the full certificate chain
+     * Creates a new CertificateEvent containing the full certificate chain.
      * @param domainKeyPair key pair used to encrypt the certificate
      * @param validationCert if this certificate is to be used for tls-apln-01 account validation
      * @param fullCertificateChain X509 certificate file
@@ -74,6 +74,11 @@ public class CertificateEvent {
         return validationCert;
     }
 
+    /**
+     * Return the full certificate chain.
+     *
+     * @return array of certificates in the chain.
+     */
     public X509Certificate[] getFullCertificateChain() {
         return fullCertificateChain;
     }

--- a/acme/src/main/java/io/micronaut/acme/events/CertificateEvent.java
+++ b/acme/src/main/java/io/micronaut/acme/events/CertificateEvent.java
@@ -27,7 +27,7 @@ public class CertificateEvent {
     private boolean validationCert;
 
     /**
-     * @deprecated See constructor that takes full certificate chain instead.
+     * @deprecated {@link #CertificateEvent(KeyPair, boolean, X509Certificate...)} instead.
      *
      * Creates a new CertificateEvent.
      * @param certificate X509 certificate file

--- a/acme/src/main/java/io/micronaut/acme/events/CertificateEvent.java
+++ b/acme/src/main/java/io/micronaut/acme/events/CertificateEvent.java
@@ -27,19 +27,28 @@ public class CertificateEvent {
     private boolean validationCert;
 
     /**
+     * @deprecated See constructor that takes full certificate chain instead.
+     *
      * Creates a new CertificateEvent.
      * @param certificate X509 certificate file
      * @param domainKeyPair key pair used to encrypt the certificate
      * @param validationCert if this certificate is to be used for tls-apln-01 account validation
      */
+    @Deprecated
     public CertificateEvent(X509Certificate certificate, KeyPair domainKeyPair, boolean validationCert) {
         this.domainKeyPair = domainKeyPair;
         this.validationCert = validationCert;
         this.fullCertificateChain = new X509Certificate[]{certificate};
     }
 
-    public CertificateEvent(KeyPair domainKeyPair, X509Certificate... fullCertificateChain) {
-        this.validationCert = false;
+    /**
+     * Creates a new CertificateEvent containing the full certificate chain
+     * @param domainKeyPair key pair used to encrypt the certificate
+     * @param validationCert if this certificate is to be used for tls-apln-01 account validation
+     * @param fullCertificateChain X509 certificate file
+     */
+    public CertificateEvent(KeyPair domainKeyPair, boolean validationCert, X509Certificate... fullCertificateChain) {
+        this.validationCert = validationCert;
         this.domainKeyPair = domainKeyPair;
         this.fullCertificateChain = fullCertificateChain;
     }

--- a/acme/src/main/java/io/micronaut/acme/events/CertificateEvent.java
+++ b/acme/src/main/java/io/micronaut/acme/events/CertificateEvent.java
@@ -24,6 +24,7 @@ import java.security.cert.X509Certificate;
 public class CertificateEvent {
     private final X509Certificate certificate;
     private final KeyPair domainKeyPair;
+    private final X509Certificate[] fullCertificateChain;
     private boolean validationCert;
 
     /**
@@ -36,6 +37,14 @@ public class CertificateEvent {
         this.certificate = certificate;
         this.domainKeyPair = domainKeyPair;
         this.validationCert = validationCert;
+        this.fullCertificateChain = new X509Certificate[]{certificate};
+    }
+
+    public CertificateEvent(KeyPair domainKeyPair, X509Certificate... fullCertificateChain) {
+        this.validationCert = false;
+        this.domainKeyPair = domainKeyPair;
+        this.certificate = fullCertificateChain[0];
+        this.fullCertificateChain = fullCertificateChain;
     }
 
     /**
@@ -57,5 +66,9 @@ public class CertificateEvent {
      */
     public boolean isValidationCert() {
         return validationCert;
+    }
+
+    public X509Certificate[] getFullCertificateChain() {
+        return fullCertificateChain;
     }
 }

--- a/acme/src/main/java/io/micronaut/acme/events/CertificateEvent.java
+++ b/acme/src/main/java/io/micronaut/acme/events/CertificateEvent.java
@@ -48,6 +48,9 @@ public class CertificateEvent {
      * @param fullCertificateChain X509 certificate file
      */
     public CertificateEvent(KeyPair domainKeyPair, boolean validationCert, X509Certificate... fullCertificateChain) {
+        if (fullCertificateChain == null || fullCertificateChain.length == 0) {
+            throw new IllegalArgumentException("Certificate chain must not be empty");
+        }
         this.validationCert = validationCert;
         this.domainKeyPair = domainKeyPair;
         this.fullCertificateChain = fullCertificateChain;

--- a/acme/src/main/java/io/micronaut/acme/events/CertificateEvent.java
+++ b/acme/src/main/java/io/micronaut/acme/events/CertificateEvent.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.acme.events;
 
+import io.micronaut.core.annotation.NonNull;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 
@@ -82,6 +83,7 @@ public class CertificateEvent {
      *
      * @return array of certificates in the chain.
      */
+    @NonNull
     public X509Certificate[] getFullCertificateChain() {
         return fullCertificateChain;
     }

--- a/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
+++ b/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
@@ -297,7 +297,7 @@ public class AcmeService {
                     try (BufferedWriter writer = Files.newBufferedWriter(domainCsr.toPath(), WRITE, CREATE, TRUNCATE_EXISTING)) {
                         certificate.writeCertificate(writer);
                     }
-                    eventPublisher.publishEvent(new CertificateEvent(domainKeyPair, getFullCertificateChain()));
+                    eventPublisher.publishEvent(new CertificateEvent(domainKeyPair, false, getFullCertificateChain()));
                     if (LOG.isInfoEnabled()) {
                         LOG.info("ACME certificate order success! Certificate URL: {}", certificate.getLocation());
                     }
@@ -481,7 +481,7 @@ public class AcmeService {
             }
             KeyPair domainKeyPair = getDomainKeyPair();
             X509Certificate tlsAlpn01Certificate = CertificateUtils.createTlsAlpn01Certificate(domainKeyPair, auth.getIdentifier(), ((TlsAlpn01Challenge) challenge).getAcmeValidation());
-            eventPublisher.publishEvent(new CertificateEvent(tlsAlpn01Certificate, domainKeyPair, true));
+            eventPublisher.publishEvent(new CertificateEvent(domainKeyPair, true, tlsAlpn01Certificate));
         } else if (challenge instanceof Http01Challenge) {
             Http01Challenge http01Challenge = (Http01Challenge) challenge;
             eventPublisher.publishEvent(new HttpChallengeDetails(http01Challenge.getToken(), http01Challenge.getAuthorization()));
@@ -501,7 +501,7 @@ public class AcmeService {
      * Setup the certificate that has been saved to disk and configures it for use.
      */
     public void setupCurrentCertificate() {
-        eventPublisher.publishEvent(new CertificateEvent(getDomainKeyPair(), getFullCertificateChain()));
+        eventPublisher.publishEvent(new CertificateEvent(getDomainKeyPair(), false, getFullCertificateChain()));
     }
 
     /**

--- a/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
+++ b/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
@@ -67,6 +67,7 @@ public class AcmeService {
     private static final Logger LOG = LoggerFactory.getLogger(AcmeService.class);
     private static final String DOMAIN_CRT = "domain.crt";
     private static final String DOMAIN_CSR = "domain.csr";
+    private static final String X509_CERT = "X.509";
 
     /**
      * Let's Encrypt has different production vs test servers.
@@ -123,7 +124,7 @@ public class AcmeService {
      */
     public X509Certificate getCurrentCertificate() {
         try {
-            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            CertificateFactory cf = CertificateFactory.getInstance(X509_CERT);
             File certificate = new File(certLocation, DOMAIN_CRT);
             if (certificate.exists()) {
                 return (X509Certificate) cf.generateCertificate(Files.newInputStream(certificate.toPath()));
@@ -145,7 +146,7 @@ public class AcmeService {
      */
     protected X509Certificate[] getFullCertificateChain() {
         try {
-            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            CertificateFactory cf = CertificateFactory.getInstance(X509_CERT);
             File certificate = new File(certLocation, DOMAIN_CRT);
             if (certificate.exists()) {
                 return cf.generateCertificates(Files.newInputStream(certificate.toPath())).toArray(new X509Certificate[0]);

--- a/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
+++ b/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
@@ -20,6 +20,7 @@ import io.micronaut.acme.challenge.dns.TxtRenderer;
 import io.micronaut.acme.challenge.http.endpoint.HttpChallengeDetails;
 import io.micronaut.acme.events.CertificateEvent;
 import io.micronaut.context.event.ApplicationEventPublisher;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.io.IOUtils;
 import io.micronaut.core.io.ResourceResolver;
 import io.micronaut.scheduling.TaskScheduler;
@@ -144,6 +145,7 @@ public class AcmeService {
      *
      * @return array of each of the certificates in the chain
      */
+    @NonNull
     protected X509Certificate[] getFullCertificateChain() {
         try {
             CertificateFactory cf = CertificateFactory.getInstance(X509_CERT);

--- a/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
+++ b/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
@@ -157,7 +157,7 @@ public class AcmeService {
             if (LOG.isWarnEnabled()) {
                 LOG.warn("Could not create certificate from file", e);
             }
-            return null;
+            return new X509Certificate[]{};
         }
     }
 

--- a/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
+++ b/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
@@ -151,7 +151,9 @@ public class AcmeService {
             CertificateFactory cf = CertificateFactory.getInstance(X509_CERT);
             File certificate = new File(certLocation, DOMAIN_CRT);
             if (certificate.exists()) {
-                return cf.generateCertificates(Files.newInputStream(certificate.toPath())).toArray(new X509Certificate[0]);
+                return cf.generateCertificates(Files.newInputStream(certificate.toPath())).stream()
+                        .map(X509Certificate.class::cast)
+                        .toArray(X509Certificate[]::new);
             } else {
                 return new X509Certificate[]{};
             }

--- a/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
+++ b/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
@@ -47,8 +47,6 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
@@ -140,6 +138,11 @@ public class AcmeService {
         }
     }
 
+    /**
+     * Returns the full certificate chain.
+     *
+     * @return array of each of the certificates in the chain
+     */
     protected X509Certificate[] getFullCertificateChain() {
         try {
             CertificateFactory cf = CertificateFactory.getInstance("X.509");

--- a/acme/src/main/java/io/micronaut/acme/ssl/AcmeSSLContextBuilder.java
+++ b/acme/src/main/java/io/micronaut/acme/ssl/AcmeSSLContextBuilder.java
@@ -77,7 +77,7 @@ public class AcmeSSLContextBuilder implements ServerSslBuilder {
                 delegatedSslContext.setNewSslContext(sslContext);
             } else {
                 SslContext sslContext = SslContextBuilder
-                        .forServer(certificateEvent.getDomainKeyPair().getPrivate(), certificateEvent.getCert())
+                        .forServer(certificateEvent.getDomainKeyPair().getPrivate(), certificateEvent.getFullCertificateChain())
                         .build();
                 delegatedSslContext.setNewSslContext(sslContext);
             }

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherMultiDomainsTaskSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherMultiDomainsTaskSpec.groovy
@@ -52,13 +52,17 @@ class AcmeCertRefresherMultiDomainsTaskSpec extends AcmeBaseSpec {
                 try {
                     conn.connect()
                     Certificate[] certs = conn.getServerCertificates()
-                    certs.length == 1
+                    certs.length == 2
                     def cert = (X509Certificate) certs[0]
                     cert.getIssuerDN().getName().contains("Pebble Intermediate CA")
                     cert.getSubjectDN().getName().contains(EXPECTED_DOMAIN)
                     cert.getSubjectAlternativeNames().size() == 2
                     cert.getSubjectAlternativeNames().collect({d-> d.get(1)}).contains(EXPECTED_DOMAIN)
                     cert.getSubjectAlternativeNames().collect({d-> d.get(1)}).contains(EXPECTED_ACME_DOMAIN)
+
+                    def cert2 = (X509Certificate) certs[1]
+                    cert2.getIssuerDN().getName().contains("Pebble Root CA")
+                    cert2.getSubjectDN().getName().contains("Pebble Intermediate CA")
                 }finally{
                     if(conn != null){
                         conn.disconnect()

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherMultiDomainsTaskSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherMultiDomainsTaskSpec.groovy
@@ -53,16 +53,16 @@ class AcmeCertRefresherMultiDomainsTaskSpec extends AcmeBaseSpec {
                     conn.connect()
                     Certificate[] certs = conn.getServerCertificates()
                     certs.length == 2
-                    def cert = (X509Certificate) certs[0]
+                    X509Certificate cert = certs[0]
                     cert.getIssuerDN().getName().contains("Pebble Intermediate CA")
                     cert.getSubjectDN().getName().contains(EXPECTED_DOMAIN)
                     cert.getSubjectAlternativeNames().size() == 2
                     cert.getSubjectAlternativeNames().collect({d-> d.get(1)}).contains(EXPECTED_DOMAIN)
                     cert.getSubjectAlternativeNames().collect({d-> d.get(1)}).contains(EXPECTED_ACME_DOMAIN)
 
-                    def cert2 = (X509Certificate) certs[1]
-                    cert2.getIssuerDN().getName().contains("Pebble Root CA")
-                    cert2.getSubjectDN().getName().contains("Pebble Intermediate CA")
+                    X509Certificate cert2 = certs[1]
+                    cert2.issuerDN.name.contains("Pebble Root CA")
+                    cert2.subjectDN.name.contains("Pebble Intermediate CA")
                 }finally{
                     if(conn != null){
                         conn.disconnect()

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskSpec.groovy
@@ -52,11 +52,15 @@ class AcmeCertRefresherTaskSpec extends AcmeBaseSpec {
                 try {
                     conn.connect()
                     Certificate[] certs = conn.getServerCertificates()
-                    certs.length == 1
+                    certs.length == 2
                     def cert = (X509Certificate) certs[0]
                     cert.getIssuerDN().getName().contains("Pebble Intermediate CA")
                     cert.getSubjectDN().getName().contains(EXPECTED_DOMAIN)
                     cert.getSubjectAlternativeNames().size() == 1
+
+                    def cert2 = (X509Certificate) certs[1]
+                    cert2.getIssuerDN().getName().contains("Pebble Root CA")
+                    cert2.getSubjectDN().getName().contains("Pebble Intermediate CA")
                 }finally{
                     if(conn != null){
                         conn.disconnect()

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskSpec.groovy
@@ -53,14 +53,14 @@ class AcmeCertRefresherTaskSpec extends AcmeBaseSpec {
                     conn.connect()
                     Certificate[] certs = conn.getServerCertificates()
                     certs.length == 2
-                    def cert = (X509Certificate) certs[0]
+                    X509Certificate cert = certs[0]
                     cert.getIssuerDN().getName().contains("Pebble Intermediate CA")
                     cert.getSubjectDN().getName().contains(EXPECTED_DOMAIN)
                     cert.getSubjectAlternativeNames().size() == 1
 
-                    def cert2 = (X509Certificate) certs[1]
-                    cert2.getIssuerDN().getName().contains("Pebble Root CA")
-                    cert2.getSubjectDN().getName().contains("Pebble Intermediate CA")
+                    X509Certificate cert2 = certs[1]
+                    cert2.issuerDN.name.contains("Pebble Root CA")
+                    cert2.subjectDN.name.contains("Pebble Intermediate CA")
                 }finally{
                     if(conn != null){
                         conn.disconnect()

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskWithClasspathKeysSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskWithClasspathKeysSpec.groovy
@@ -68,14 +68,14 @@ class AcmeCertRefresherTaskWithClasspathKeysSpec extends AcmeBaseSpec {
                     conn.connect()
                     Certificate[] certs = conn.getServerCertificates()
                     certs.length == 2
-                    def cert = (X509Certificate) certs[0]
+                    X509Certificate cert = certs[0]
                     cert.getIssuerDN().getName().contains("Pebble Intermediate CA")
                     cert.getSubjectDN().getName().contains(EXPECTED_DOMAIN)
                     cert.getSubjectAlternativeNames().size() == 1
 
-                    def cert2 = (X509Certificate) certs[1]
-                    cert2.getIssuerDN().getName().contains("Pebble Root CA")
-                    cert2.getSubjectDN().getName().contains("Pebble Intermediate CA")
+                    X509Certificate cert2 = certs[1]
+                    cert2.issuerDN.name.contains("Pebble Root CA")
+                    cert2.subjectDN.name.contains("Pebble Intermediate CA")
                 }finally{
                     if(conn != null){
                         conn.disconnect()

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskWithClasspathKeysSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskWithClasspathKeysSpec.groovy
@@ -67,11 +67,15 @@ class AcmeCertRefresherTaskWithClasspathKeysSpec extends AcmeBaseSpec {
                 try {
                     conn.connect()
                     Certificate[] certs = conn.getServerCertificates()
-                    certs.length == 1
+                    certs.length == 2
                     def cert = (X509Certificate) certs[0]
                     cert.getIssuerDN().getName().contains("Pebble Intermediate CA")
                     cert.getSubjectDN().getName().contains(EXPECTED_DOMAIN)
                     cert.getSubjectAlternativeNames().size() == 1
+
+                    def cert2 = (X509Certificate) certs[1]
+                    cert2.getIssuerDN().getName().contains("Pebble Root CA")
+                    cert2.getSubjectDN().getName().contains("Pebble Intermediate CA")
                 }finally{
                     if(conn != null){
                         conn.disconnect()

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskWithFileKeysSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskWithFileKeysSpec.groovy
@@ -61,11 +61,15 @@ class AcmeCertRefresherTaskWithFileKeysSpec extends AcmeBaseSpec {
                 try {
                     conn.connect()
                     Certificate[] certs = conn.getServerCertificates()
-                    certs.length == 1
+                    certs.length == 2
                     def cert = (X509Certificate) certs[0]
                     cert.getIssuerDN().getName().contains("Pebble Intermediate CA")
                     cert.getSubjectDN().getName().contains(EXPECTED_DOMAIN)
                     cert.getSubjectAlternativeNames().size() == 1
+
+                    def cert2 = (X509Certificate) certs[1]
+                    cert2.getIssuerDN().getName().contains("Pebble Root CA")
+                    cert2.getSubjectDN().getName().contains("Pebble Intermediate CA")
                 }finally{
                     if(conn != null){
                         conn.disconnect()

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskWithFileKeysSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskWithFileKeysSpec.groovy
@@ -62,14 +62,14 @@ class AcmeCertRefresherTaskWithFileKeysSpec extends AcmeBaseSpec {
                     conn.connect()
                     Certificate[] certs = conn.getServerCertificates()
                     certs.length == 2
-                    def cert = (X509Certificate) certs[0]
+                    X509Certificate cert = certs[0]
                     cert.getIssuerDN().getName().contains("Pebble Intermediate CA")
                     cert.getSubjectDN().getName().contains(EXPECTED_DOMAIN)
                     cert.getSubjectAlternativeNames().size() == 1
 
-                    def cert2 = (X509Certificate) certs[1]
-                    cert2.getIssuerDN().getName().contains("Pebble Root CA")
-                    cert2.getSubjectDN().getName().contains("Pebble Intermediate CA")
+                    X509Certificate cert2 = certs[1]
+                    cert2.issuerDN.name.contains("Pebble Root CA")
+                    cert2.subjectDN.name.contains("Pebble Intermediate CA")
                 }finally{
                     if(conn != null){
                         conn.disconnect()

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeCertWildcardRefresherTaskSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeCertWildcardRefresherTaskSpec.groovy
@@ -58,16 +58,16 @@ class AcmeCertWildcardRefresherTaskSpec extends AcmeBaseSpec {
                 conn.connect()
                 Certificate[] certs = conn.getServerCertificates()
                 certs.length == 2
-                def cert = (X509Certificate) certs[0]
+                X509Certificate cert = certs[0]
                 cert.getIssuerDN().getName().contains("Pebble Intermediate CA")
                 cert.getSubjectDN().getName().contains(WILDCARD_DOMAIN)
                 cert.getSubjectAlternativeNames().size() == 2
                 cert.getSubjectAlternativeNames().collect({d-> d.get(1)}).contains(WILDCARD_DOMAIN)
                 cert.getSubjectAlternativeNames().collect({d-> d.get(1)}).contains(EXPECTED_BASE_DOMAIN)
 
-                def cert2 = (X509Certificate) certs[1]
-                cert2.getIssuerDN().getName().contains("Pebble Root CA")
-                cert2.getSubjectDN().getName().contains("Pebble Intermediate CA")
+                X509Certificate cert2 = certs[1]
+                cert2.issuerDN.name.contains("Pebble Root CA")
+                cert2.subjectDN.name.contains("Pebble Intermediate CA")
             }finally{
                 if(conn != null){
                     conn.disconnect()

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeCertWildcardRefresherTaskSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeCertWildcardRefresherTaskSpec.groovy
@@ -57,13 +57,17 @@ class AcmeCertWildcardRefresherTaskSpec extends AcmeBaseSpec {
             try {
                 conn.connect()
                 Certificate[] certs = conn.getServerCertificates()
-                certs.length == 1
+                certs.length == 2
                 def cert = (X509Certificate) certs[0]
                 cert.getIssuerDN().getName().contains("Pebble Intermediate CA")
                 cert.getSubjectDN().getName().contains(WILDCARD_DOMAIN)
                 cert.getSubjectAlternativeNames().size() == 2
                 cert.getSubjectAlternativeNames().collect({d-> d.get(1)}).contains(WILDCARD_DOMAIN)
                 cert.getSubjectAlternativeNames().collect({d-> d.get(1)}).contains(EXPECTED_BASE_DOMAIN)
+
+                def cert2 = (X509Certificate) certs[1]
+                cert2.getIssuerDN().getName().contains("Pebble Root CA")
+                cert2.getSubjectDN().getName().contains("Pebble Intermediate CA")
             }finally{
                 if(conn != null){
                     conn.disconnect()

--- a/acme/src/test/groovy/io/micronaut/acme/challenges/AcmeCertRefresherTaskHttp01ChallengeSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/challenges/AcmeCertRefresherTaskHttp01ChallengeSpec.groovy
@@ -62,14 +62,14 @@ class AcmeCertRefresherTaskHttp01ChallengeSpec extends AcmeBaseSpec {
 
         then: "we make sure they are from the pebble test server and the domain is as expected"
             certs.length == 2
-            def cert = (X509Certificate) certs[0]
+            X509Certificate cert = certs[0]
             cert.getIssuerDN().getName().contains("Pebble Intermediate CA")
             cert.getSubjectDN().getName().contains(EXPECTED_ACME_DOMAIN)
             cert.getSubjectAlternativeNames().size() == 1
 
-            def cert2 = (X509Certificate) certs[1]
-            cert2.getIssuerDN().getName().contains("Pebble Root CA")
-            cert2.getSubjectDN().getName().contains("Pebble Intermediate CA")
+            X509Certificate cert2 = certs[1]
+            cert2.issuerDN.name.contains("Pebble Root CA")
+            cert2.subjectDN.name.contains("Pebble Intermediate CA")
     }
 
     void "test send https request when the cert is in place"() {

--- a/acme/src/test/groovy/io/micronaut/acme/challenges/AcmeCertRefresherTaskHttp01ChallengeSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/challenges/AcmeCertRefresherTaskHttp01ChallengeSpec.groovy
@@ -61,11 +61,15 @@ class AcmeCertRefresherTaskHttp01ChallengeSpec extends AcmeBaseSpec {
             Certificate[] certs = conn.getServerCertificates()
 
         then: "we make sure they are from the pebble test server and the domain is as expected"
-            certs.length == 1
+            certs.length == 2
             def cert = (X509Certificate) certs[0]
             cert.getIssuerDN().getName().contains("Pebble Intermediate CA")
             cert.getSubjectDN().getName().contains(EXPECTED_ACME_DOMAIN)
             cert.getSubjectAlternativeNames().size() == 1
+
+            def cert2 = (X509Certificate) certs[1]
+            cert2.getIssuerDN().getName().contains("Pebble Root CA")
+            cert2.getSubjectDN().getName().contains("Pebble Intermediate CA")
     }
 
     void "test send https request when the cert is in place"() {

--- a/acme/src/test/groovy/io/micronaut/acme/challenges/AcmeCertRefresherTaskTlsApln01ChallengeSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/challenges/AcmeCertRefresherTaskTlsApln01ChallengeSpec.groovy
@@ -59,11 +59,15 @@ class AcmeCertRefresherTaskTlsApln01ChallengeSpec extends AcmeBaseSpec {
             Certificate[] certs = conn.getServerCertificates()
 
         then: "we make sure they are from the pebble test server and the domain is as expected"
-            certs.length == 1
+            certs.length == 2
             def cert = (X509Certificate) certs[0]
             cert.getIssuerDN().getName().contains("Pebble Intermediate CA")
             cert.getSubjectDN().getName().contains(EXPECTED_ACME_DOMAIN)
             cert.getSubjectAlternativeNames().size() == 1
+
+            def cert2 = (X509Certificate) certs[1]
+            cert2.getIssuerDN().getName().contains("Pebble Root CA")
+            cert2.getSubjectDN().getName().contains("Pebble Intermediate CA")
     }
 
     void "test send https request when the cert is in place"() {

--- a/acme/src/test/groovy/io/micronaut/acme/challenges/AcmeCertRefresherTaskTlsApln01ChallengeSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/challenges/AcmeCertRefresherTaskTlsApln01ChallengeSpec.groovy
@@ -60,14 +60,14 @@ class AcmeCertRefresherTaskTlsApln01ChallengeSpec extends AcmeBaseSpec {
 
         then: "we make sure they are from the pebble test server and the domain is as expected"
             certs.length == 2
-            def cert = (X509Certificate) certs[0]
+            X509Certificate cert = certs[0]
             cert.getIssuerDN().getName().contains("Pebble Intermediate CA")
             cert.getSubjectDN().getName().contains(EXPECTED_ACME_DOMAIN)
             cert.getSubjectAlternativeNames().size() == 1
 
-            def cert2 = (X509Certificate) certs[1]
-            cert2.getIssuerDN().getName().contains("Pebble Root CA")
-            cert2.getSubjectDN().getName().contains("Pebble Intermediate CA")
+            X509Certificate cert2 = certs[1]
+            cert2.issuerDN.name.contains("Pebble Root CA")
+            cert2.subjectDN.name.contains("Pebble Intermediate CA")
     }
 
     void "test send https request when the cert is in place"() {

--- a/acme/src/test/groovy/io/micronaut/acme/events/CertificateEventSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/events/CertificateEventSpec.groovy
@@ -1,0 +1,120 @@
+package io.micronaut.acme.events
+
+
+import org.shredzone.acme4j.util.KeyPairUtils
+import spock.lang.Specification
+
+import java.security.KeyPair
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+
+class CertificateEventSpec extends Specification {
+    def DOMAIN_CERT = """
+-----BEGIN CERTIFICATE-----
+MIIDUDCCAjigAwIBAgIIHuspA0mthF8wDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
+AxMVUGViYmxlIFJvb3QgQ0EgMTU5ZjdmMCAXDTIxMDcxODIxMDczNloYDzIwNTEw
+NzE4MjEwNzM2WjAoMSYwJAYDVQQDEx1QZWJibGUgSW50ZXJtZWRpYXRlIENBIDY2
+NjViYjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALnw4xa4KQCxbhiW
+1o1VYVUbof2mWwkhsWRuws4Uc1kvAVM7k1RZvwNxGQLgJkdXjbUrctddHdFMtksN
+imNy/nmB6LKoulzwDL1omCdaiYOxJr93cGYQC3FTm/RaTpaHuec+BaB2Y1iOzbBj
+sLL9121eRWUZ0vjaqKwNO8NUlK/geELNgoteIJ1MjOzWp1bryjnaszBfg0eiidD8
+4gV36fvrM1UVJZJ4LBV4QHrKVXl7JA5hn9uk7zucH/XEG87DO2DCWJIwZK9Fm8wD
+qMmvx/QH+dwXOXe6kXTDuyu7jJMoHDBLNQ9o4gjkqqHxA1f0ewgo64ObJ09hx+96
+fuC49x8CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCAoQwHQYDVR0lBBYwFAYIKwYB
+BQUHAwEGCCsGAQUFBwMCMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFA56gdVb
++6pOjZzcKcjPhe7fWr5WMB8GA1UdIwQYMBaAFD8kVZzZs7SeJSiQFrf5AsH/EFmv
+MA0GCSqGSIb3DQEBCwUAA4IBAQApcSZ5s0VGT1KgsXh3GrqxwlSyFfVuE4qvMabf
+rXAhUbG3C6hgdA2AWA5IUvI9fRqul6m88hLZc8hrgOJ0vGDAD2u/PMdrqtAz8fV4
+gch5z+Jn4J+9Af7hOm3DSFtVRqvbtyWTT2ht7wJbtxAOsuD7+Wa6lr+lZxhHXbRv
+RpY6uVNZNlnC5k8BFnx8S9SdsK+upYtkgyKLoFpDhyXgmFMJPGA7UY6NQQ1sA/2x
+dwYXMfCY829k0hcxcXYC4SYDjwHxF6YIM4lYS8pT0Z8d98H5cK7WNwFmW+izu6cx
+87DDk/ZlkyArnozVQ6GFJClfhbKZfPKty1r1Y1psSOAUcUD1
+-----END CERTIFICATE-----
+"""
+
+    def ROOT_CERTIFICATE = """
+-----BEGIN CERTIFICATE-----
+MIIDezCCAmOgAwIBAgIIBzCDqTIFEj8wDQYJKoZIhvcNAQELBQAwKDEmMCQGA1UE
+AxMdUGViYmxlIEludGVybWVkaWF0ZSBDQSA2NjY1YmIwHhcNMjEwNzE4MjEwNzQx
+WhcNMjYwNzE4MjEwNzQxWjAnMSUwIwYDVQQDExxob3N0LnRlc3Rjb250YWluZXJz
+LmludGVybmFsMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiwwiBiCF
+q1oMiXSOvEjCKkSR5lGu9CDW9UFQgN/UhVG2RyuDojImUOQjOjHe/DWn7g1XKovT
+3it/M1onAnmksvqFd6YwSUKT8epL1K0dyVzgwaPAgjpJZgt/IZvA9ATWILuMJDGB
+jdRRUQ+xex3AVbwa5UJYPlK2t1yqL5YPP9WpZ8H3c1F6M2by5VbwIi78LSxPc47m
+H35efxWX2DalsDYirgP3bL0/X/yeVw058Iga+9MsF5MELDMuh9fe5N81TcrtKHvW
+W4DfBPUFSnA/52G/nltZdgXxyMgErgwHx86dQphZMAGAD+wCXnzewAI9ZWN4iU27
+IiP1kQqVP33AoQIDAQABo4GpMIGmMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAU
+BggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUFXuU
+GdoN4vOZ3IiyvXkQw2Dd92cwHwYDVR0jBBgwFoAUDnqB1Vv7qk6NnNwpyM+F7t9a
+vlYwJwYDVR0RBCAwHoIcaG9zdC50ZXN0Y29udGFpbmVycy5pbnRlcm5hbDANBgkq
+hkiG9w0BAQsFAAOCAQEAEJNY7olfzudkko1FcGq5bCauwB9240uu67YUIJG7y54G
+tq2XWYWQ19FAqgb/7iWKq5X2hjp3Ut3x76SCwOKy5Q0dArcxwQYVgMMj9znxH6LL
+QBJOPgQDvnxysEXEu4zvR/GV6ZS5ndFKJAPJxklZkdGhhqp15gUnP/1qTGPLEC5j
+7gR/TfCwWsiMvkBmkYyacDvIHPd8QHtISNhL5Y+dww8DeL+F4ALC1dFLdAaT/bdx
+RVv802SMY7YAh8FAsnTsKLYNbSk6ZHVbJuBcVbHqGuWueZ43hwmOTF6pIDaIoBg1
+zSti1w9hjz913WF0dTg7RWFLU8e3Jo1O9MCnORtcgg==
+-----END CERTIFICATE-----"""
+
+    def FULL_CHAIN_CERT = """
+${ROOT_CERTIFICATE}
+${DOMAIN_CERT}
+"""
+
+    def "can get domain keypair"(){
+        given:
+        CertificateFactory cf = CertificateFactory.getInstance("X.509")
+        X509Certificate cert = cf.generateCertificate(new ByteArrayInputStream(FULL_CHAIN_CERT.bytes))
+        KeyPair keyPair = KeyPairUtils.createKeyPair(2048)
+
+        when :
+        CertificateEvent event = new CertificateEvent(cert, keyPair, new Random().nextBoolean())
+
+        then:
+        event.getDomainKeyPair() == keyPair
+    }
+
+    def "can determine if the event is a validation certificate or not"(){
+        given:
+        CertificateFactory cf = CertificateFactory.getInstance("X.509")
+        X509Certificate cert = cf.generateCertificate(new ByteArrayInputStream(FULL_CHAIN_CERT.bytes))
+        KeyPair keyPair = KeyPairUtils.createKeyPair(2048)
+        def validationCert = new Random().nextBoolean()
+
+        when :
+        CertificateEvent event = new CertificateEvent(cert, keyPair, validationCert)
+
+        then:
+        event.isValidationCert() == validationCert
+    }
+
+    def "when pass single cert the full chain only contains that cert"(){
+        given:
+            CertificateFactory cf = CertificateFactory.getInstance("X.509")
+            X509Certificate domainCert = cf.generateCertificate(new ByteArrayInputStream(FULL_CHAIN_CERT.bytes))
+            KeyPair keyPair = KeyPairUtils.createKeyPair(2048)
+
+        when :
+            CertificateEvent event = new CertificateEvent(domainCert, keyPair, new Random().nextBoolean())
+
+        then:
+            event.getCert() == domainCert
+            event.getFullCertificateChain().length == 1
+            event.getFullCertificateChain()[0] == domainCert
+    }
+
+    def "when full certificate chain passed we can still get the domain specific cert"(){
+        given:
+        CertificateFactory cf = CertificateFactory.getInstance("X.509")
+        X509Certificate domainCert = cf.generateCertificate(new ByteArrayInputStream(FULL_CHAIN_CERT.bytes))
+        Collection<X509Certificate> certs = cf.generateCertificates(new ByteArrayInputStream(FULL_CHAIN_CERT.bytes))
+        KeyPair keyPair = KeyPairUtils.createKeyPair(2048)
+
+        when :
+        CertificateEvent event = new CertificateEvent(keyPair, certs as X509Certificate[])
+
+        then:
+        event.getCert() == domainCert
+        event.getFullCertificateChain().length == 2
+        event.getFullCertificateChain() == certs.toArray()
+    }
+}

--- a/acme/src/test/groovy/io/micronaut/acme/events/CertificateEventSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/events/CertificateEventSpec.groovy
@@ -9,6 +9,8 @@ import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 
 class CertificateEventSpec extends Specification {
+    static final String X509_CERT = "X.509"
+
     def DOMAIN_CERT = """
 -----BEGIN CERTIFICATE-----
 MIIDUDCCAjigAwIBAgIIHuspA0mthF8wDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
@@ -62,7 +64,7 @@ ${DOMAIN_CERT}
 
     def "can get domain keypair"(){
         given:
-        CertificateFactory cf = CertificateFactory.getInstance("X.509")
+        CertificateFactory cf = CertificateFactory.getInstance(X509_CERT)
         X509Certificate cert = cf.generateCertificate(new ByteArrayInputStream(FULL_CHAIN_CERT.bytes))
         KeyPair keyPair = KeyPairUtils.createKeyPair(2048)
 
@@ -75,7 +77,7 @@ ${DOMAIN_CERT}
 
     def "can determine if the event is a validation certificate or not"(){
         given:
-        CertificateFactory cf = CertificateFactory.getInstance("X.509")
+        CertificateFactory cf = CertificateFactory.getInstance(X509_CERT)
         X509Certificate cert = cf.generateCertificate(new ByteArrayInputStream(FULL_CHAIN_CERT.bytes))
         KeyPair keyPair = KeyPairUtils.createKeyPair(2048)
         def validationCert = new Random().nextBoolean()
@@ -89,7 +91,7 @@ ${DOMAIN_CERT}
 
     def "when pass single cert the full chain only contains that cert"(){
         given:
-            CertificateFactory cf = CertificateFactory.getInstance("X.509")
+            CertificateFactory cf = CertificateFactory.getInstance(X509_CERT)
             X509Certificate domainCert = cf.generateCertificate(new ByteArrayInputStream(FULL_CHAIN_CERT.bytes))
             KeyPair keyPair = KeyPairUtils.createKeyPair(2048)
 
@@ -104,7 +106,7 @@ ${DOMAIN_CERT}
 
     def "when full certificate chain passed we can still get the domain specific cert"(){
         given:
-        CertificateFactory cf = CertificateFactory.getInstance("X.509")
+        CertificateFactory cf = CertificateFactory.getInstance(X509_CERT)
         X509Certificate domainCert = cf.generateCertificate(new ByteArrayInputStream(FULL_CHAIN_CERT.bytes))
         Collection<X509Certificate> certs = cf.generateCertificates(new ByteArrayInputStream(FULL_CHAIN_CERT.bytes))
         KeyPair keyPair = KeyPairUtils.createKeyPair(2048)

--- a/acme/src/test/groovy/io/micronaut/acme/events/CertificateEventSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/events/CertificateEventSpec.groovy
@@ -80,7 +80,7 @@ ${DOMAIN_CERT}
         CertificateFactory cf = CertificateFactory.getInstance(X509_CERT)
         X509Certificate cert = cf.generateCertificate(new ByteArrayInputStream(FULL_CHAIN_CERT.bytes))
         KeyPair keyPair = KeyPairUtils.createKeyPair(2048)
-        def validationCert = new Random().nextBoolean()
+        boolean validationCert = new Random().nextBoolean()
 
         when :
         CertificateEvent event = new CertificateEvent(cert, keyPair, validationCert)
@@ -110,7 +110,7 @@ ${DOMAIN_CERT}
         X509Certificate domainCert = cf.generateCertificate(new ByteArrayInputStream(FULL_CHAIN_CERT.bytes))
         Collection<X509Certificate> certs = cf.generateCertificates(new ByteArrayInputStream(FULL_CHAIN_CERT.bytes))
         KeyPair keyPair = KeyPairUtils.createKeyPair(2048)
-        def expectedValidationCert = new Random().nextBoolean()
+        boolean expectedValidationCert = new Random().nextBoolean()
 
         when :
         CertificateEvent event = new CertificateEvent(keyPair, expectedValidationCert, certs as X509Certificate[])

--- a/acme/src/test/groovy/io/micronaut/acme/events/CertificateEventSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/events/CertificateEventSpec.groovy
@@ -108,12 +108,14 @@ ${DOMAIN_CERT}
         X509Certificate domainCert = cf.generateCertificate(new ByteArrayInputStream(FULL_CHAIN_CERT.bytes))
         Collection<X509Certificate> certs = cf.generateCertificates(new ByteArrayInputStream(FULL_CHAIN_CERT.bytes))
         KeyPair keyPair = KeyPairUtils.createKeyPair(2048)
+        def expectedValidationCert = new Random().nextBoolean()
 
         when :
-        CertificateEvent event = new CertificateEvent(keyPair, certs as X509Certificate[])
+        CertificateEvent event = new CertificateEvent(keyPair, expectedValidationCert, certs as X509Certificate[])
 
         then:
         event.getCert() == domainCert
+        event.isValidationCert() == expectedValidationCert
         event.getFullCertificateChain().length == 2
         event.getFullCertificateChain() == certs.toArray()
     }

--- a/acme/src/test/groovy/io/micronaut/acme/events/CertificateEventSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/events/CertificateEventSpec.groovy
@@ -69,7 +69,7 @@ ${DOMAIN_CERT}
         KeyPair keyPair = KeyPairUtils.createKeyPair(2048)
 
         when :
-        CertificateEvent event = new CertificateEvent(cert, keyPair, new Random().nextBoolean())
+        CertificateEvent event = new CertificateEvent(keyPair, new Random().nextBoolean(), cert)
 
         then:
         event.getDomainKeyPair() == keyPair
@@ -83,7 +83,7 @@ ${DOMAIN_CERT}
         boolean validationCert = new Random().nextBoolean()
 
         when :
-        CertificateEvent event = new CertificateEvent(cert, keyPair, validationCert)
+        CertificateEvent event = new CertificateEvent(keyPair, validationCert, cert)
 
         then:
         event.isValidationCert() == validationCert
@@ -96,7 +96,7 @@ ${DOMAIN_CERT}
             KeyPair keyPair = KeyPairUtils.createKeyPair(2048)
 
         when :
-            CertificateEvent event = new CertificateEvent(domainCert, keyPair, new Random().nextBoolean())
+            CertificateEvent event = new CertificateEvent(keyPair, new Random().nextBoolean(), domainCert)
 
         then:
             event.getCert() == domainCert


### PR DESCRIPTION
Fixes #156 and #73 

Found that we were parsing the cert using
CertificateFactory.getCertificate. This was not giving us the full chain
but instead just the domain cert. Which in most places work but not in
all.

To address this we now will get the full chain using
CertificateFactor.getCertificates and pass that on the event to Netty so
that it can be used for initialization.