### PR TITLE
Replace TxtRenderer with a replaceable bean to allow users to impleme…

### DIFF
--- a/acme/src/main/java/io/micronaut/acme/challenge/dns/DnsChallengeSolver.java
+++ b/acme/src/main/java/io/micronaut/acme/challenge/dns/DnsChallengeSolver.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.acme.challenge.dns;
+
+import io.micronaut.context.annotation.DefaultImplementation;
+
+/**
+ * Represents a solver for the DNS challenge that can create and destroy
+ * DNS records.
+ */
+@DefaultImplementation(RenderedTextDnsChallengeSolver.class)
+public interface DnsChallengeSolver {
+    /**
+     * Creates the TXT record for `_acme-challenge.<i>domain</i>`
+     * with a value of <i>digest</i> to verify the domain.
+     *
+     * <p>This method should block and only return once the TXT record has been
+     * created, however {@see io.micronaut.acme.AcmeConfiguration} `pause` setting can also be
+     * used to provide time for propagation.</p>
+     *
+     * @param domain    The domain to create the record for, excluding the `_acme-challenge` key
+     * @param digest    The value to set the TXT record to for the challenge to succeed
+     */
+    void createRecord(String domain, String digest);
+
+    /**
+     * Remove the TXT record previously created for the challenge.
+     *
+     * <p>This method is called even if the challenge failed, so it is possible the record may not exist.</p>
+     *
+     * @param domain    The domain to remove the record for, excluding the `_acme-challenge` key
+     */
+    void destroyRecord(String domain);
+}

--- a/acme/src/main/java/io/micronaut/acme/challenge/dns/RenderedTextDnsChallengeSolver.java
+++ b/acme/src/main/java/io/micronaut/acme/challenge/dns/RenderedTextDnsChallengeSolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2021 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,34 @@
  */
 package io.micronaut.acme.challenge.dns;
 
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
- * TXT renderer needed for DNS Acme challenge server validation to be possible.
+ * Default DNS challenge solver which simply prints instructions to STDOUT to manually create a record.
  */
-public final class TxtRenderer {
-    /**
-     * Outputs the values needed for DNS challenge authorization. These values will need to be manually entered into your
-     * DNS provider so that they can be retrieved by the challenge server.
-     * @param digest the value that the challenge server is expecting in the TXT record
-     * @param domain domain name to create the record for
-     */
-    public void render(String digest, String domain) {
+@Singleton
+class RenderedTextDnsChallengeSolver implements DnsChallengeSolver {
+    private static final String TXT_RECORD_NAME = "_acme-challenge";
+    private static final Logger LOG = LoggerFactory.getLogger(RenderedTextDnsChallengeSolver.class);
+
+    @Override
+    public void createRecord(String domain, String digest) {
         System.out.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
         System.out.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
         System.out.println("\t\t\t\t\t\t\tCREATE DNS `TXT` ENTRY AS FOLLOWS");
-        System.out.println("\t\t\t\t_acme-challenge." + domain + " with value " + digest);
+        System.out.println("\t\t\t\t" + TXT_RECORD_NAME + "." + domain + " with value " + digest);
         System.out.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
         System.out.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+    }
+
+    @Override
+    public void destroyRecord(String domain) {
+        // To maintain backwards compatibility with <=v3.0.1, do not print text
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("The 'TXT' record for " + TXT_RECORD_NAME + "." + domain + " can be removed");
+        }
     }
 }

--- a/acme/src/main/resources/META-INF/native-image/io.micronaut.acme/micronaut-acme/native-image.properties
+++ b/acme/src/main/resources/META-INF/native-image/io.micronaut.acme/micronaut-acme/native-image.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-Args = --initialize-at-run-time=io.netty.handler.ssl.OpenSsl,io.netty.handler.ssl.OpenSslPrivateKeyMethod,io.netty.internal.tcnative.CertificateVerifier,io.netty.internal.tcnative.SSL,io.netty.internal.tcnative.SSLPrivateKeyMethod,io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod
+Args = --initialize-at-run-time=io.netty.handler.ssl.OpenSsl,io.netty.handler.ssl.OpenSslPrivateKeyMethod,io.netty.internal.tcnative.CertificateVerifier,io.netty.internal.tcnative.SSL,io.netty.internal.tcnative.SSLPrivateKeyMethod,io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod,io.netty.handler.ssl.OpenSslAsyncPrivateKeyMethod

--- a/acme/src/test/groovy/io/micronaut/acme/challenges/AcmeCertRefresherTaskDns01ChallengeSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/challenges/AcmeCertRefresherTaskDns01ChallengeSpec.groovy
@@ -1,0 +1,123 @@
+package io.micronaut.acme.challenges
+
+import io.micronaut.acme.AcmeBaseSpec
+import io.micronaut.acme.challenge.dns.DnsChallengeSolver
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory
+import io.reactivex.Flowable
+import jakarta.inject.Singleton
+import spock.lang.Stepwise
+import spock.util.concurrent.PollingConditions
+
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLContext
+import java.security.SecureRandom
+import java.security.cert.Certificate
+import java.security.cert.X509Certificate
+
+@Stepwise
+class AcmeCertRefresherTaskDns01ChallengeSpec extends AcmeBaseSpec {
+    Map<String, Object> getConfiguration(){
+        super.getConfiguration() << [
+                "acme.domains": EXPECTED_ACME_DOMAIN,
+                "acme.challenge-type" : "dns",
+                "micronaut.server.dualProtocol": true,
+                "micronaut.server.port" : expectedHttpPort
+        ]
+    }
+
+    @Override
+    Map<String, String> getPebbleEnv(){
+        return [
+                "PEBBLE_VA_ALWAYS_VALID": "1"
+        ]
+    }
+
+    def "get new certificate using existing account"() {
+        expect:
+            new PollingConditions(timeout: 30).eventually {
+                certFolder.list().length == 2
+                certFolder.list().contains("domain.crt")
+                certFolder.list().contains("domain.csr")
+            }
+    }
+
+    def "expect record to be created and match domain"() {
+        expect:
+        TestDnsChallengeSolver.createdRecords.size() == 1
+        TestDnsChallengeSolver.createdRecords.containsKey(EXPECTED_ACME_DOMAIN)
+        TestDnsChallengeSolver.createdRecords[EXPECTED_ACME_DOMAIN].length() > 1
+    }
+
+    def "expect record to be destroyed and match domain"() {
+        expect:
+        TestDnsChallengeSolver.purgedRecords == [EXPECTED_ACME_DOMAIN]
+    }
+
+    void "expect the url to be https"() {
+        expect:
+            embeddedServer.getURL().toString() == "https://$EXPECTED_DOMAIN:$expectedSecurePort"
+    }
+
+    void "test certificate is one from pebble server"() {
+        given: "we allow java to trust all certs since the test certs are not 100% valid"
+            SSLContext sc = SSLContext.getInstance("SSL")
+            sc.init(null, InsecureTrustManagerFactory.INSTANCE.trustManagers, new SecureRandom())
+            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory())
+
+        when: "we get the cert that has been setup"
+            URL destinationURL = new URL(embeddedServer.getURL().toString() + "/dnschallenge")
+            HttpsURLConnection conn = (HttpsURLConnection) destinationURL.openConnection()
+            conn.connect()
+            Certificate[] certs = conn.getServerCertificates()
+
+        then: "we make sure they are from the pebble test server and the domain is as expected"
+            certs.length == 1
+            def cert = (X509Certificate) certs[0]
+            cert.getIssuerDN().getName().contains("Pebble Intermediate CA")
+            cert.getSubjectDN().getName().contains(EXPECTED_ACME_DOMAIN)
+            cert.getSubjectAlternativeNames().size() == 1
+    }
+
+    void "test send https request when the cert is in place"() {
+        when:
+            Flowable<HttpResponse<String>> flowable = Flowable.fromPublisher(client.exchange(
+                    HttpRequest.GET("/dnschallenge"), String
+            ))
+            HttpResponse<String> response = flowable.blockingFirst()
+
+        then:
+            response.body() == "Hello DNS"
+    }
+
+    @Controller('/')
+    static class SslController {
+
+        @Get('/dnschallenge')
+        String simple() {
+            return "Hello DNS"
+        }
+
+    }
+
+    @Singleton
+    @Replaces(DnsChallengeSolver.class)
+    static class TestDnsChallengeSolver implements DnsChallengeSolver {
+        static Map<String, String> createdRecords = [:]
+        static List<String> purgedRecords = []
+
+        @Override
+        void createRecord(String domain, String digest) {
+            createdRecords.put(domain, digest)
+        }
+
+        @Override
+        void destroyRecord(String domain) {
+            purgedRecords.add(domain)
+        }
+    }
+}

--- a/examples/hello-world-acme/src/main/resources/application-dns.yml
+++ b/examples/hello-world-acme/src/main/resources/application-dns.yml
@@ -1,7 +1,7 @@
 acme:
   challenge-type: 'dns'
   auth:
-    # Due to the current manual nature in which the dns validation has to be done currently
+    # Due to the current manual nature in which the dns validation is performed by default
     # we change the amount of time we wait before trying to authorize again to make sure there
     # is time for us logging into the dns interface, setting a TXT record and waiting for it
     # to propagate.

--- a/src/main/docs/guide/challenges/dns.adoc
+++ b/src/main/docs/guide/challenges/dns.adoc
@@ -1,5 +1,7 @@
-Utilizing `dns` challenge type allows validation to be done via entry of a DNS TXT record. Currently
-the application will log out a message that looks as follows.
+Utilizing `dns` challenge type allows validation to be done via entry of a DNS TXT record.
+
+=== Manual Verification
+By default, the application will log out a message that looks as follows.
 
 .DNS output
 [source]
@@ -17,7 +19,7 @@ Once this is output you will need to log into your DNS provider and create a TXT
 * key: `_acme-challenge.example.com`
 * value: `79ZNJaxlcLYIFootHL6Rrbh2VUCfFGgPeurVyjoRrS8`
 
-Since this is a manual process you will also want to bump out your `acme.auth.pause` duration so that there is enough time between retries
+Since this is a manual process you will also want to bump up your `acme.auth.pause` duration so that there is enough time between retries
 and time take for the manual entry/DNS propagation.
 
 .src/main/resources/application.yml
@@ -26,9 +28,31 @@ and time take for the manual entry/DNS propagation.
 acme:
   challenge-type: 'dns'
   auth:
-    # Due to the current manual nature in which the dns validation has to be done currently
+    # Due to the current manual nature in which the dns validation is performed by default
     # we change the amount of time we wait before trying to authorize again to make sure there
     # is time for us logging into the dns interface, setting a TXT record and waiting for it
     # to propagate.
     pause: 2m
+----
+
+=== Automatic Verification
+
+An implementation of api:acme.challenge.dns.DnsChallengeSolver[] can be provided to automate the creation and cleanup of the necessary DNS records.
+
+.CustomDnsChallengeSolver.java
+[source, java]
+----
+@Singleton
+@Replaces(DnsChallengeSolver.class)
+class CustomDnsChallengeSolver implements DnsChallengeSolver {
+    @Override
+    public void createRecord(String domain, String digest) {
+        // Create a TXT record for $domain with the key "_acme-challenge" and the value of $digest
+    }
+
+    @Override
+    public void destroyRecord(String domain) {
+        // Remove the TXT record for $domain with the key "_acme-challenge" if it exists
+    }
+}
 ----

--- a/src/main/docs/guide/challenges/tls.adoc
+++ b/src/main/docs/guide/challenges/tls.adoc
@@ -1,4 +1,4 @@
-Utilizing `tls` challenge type is the simpliest to configure and thus the default because you will only be required
+Utilizing `tls` challenge type is the simplest to configure and thus the default because you will only be required
 to open up the default secure port for the server to allow the challenge server to validate it.
 
 .src/main/resources/application.yml


### PR DESCRIPTION
…nt their own DNS challenge support

* Replace TxtRenderer with a replaceable bean to allow users to implement their own DNS challenge support

* Adds test for DNS challenge, but avoids implementing an entire DNS server

* Adds basic documentation for the bean

* Fixes typo in TLS challenge docs

* Add io.netty.handler.ssl.OpenSslAsyncPrivateKeyMethod to GraalVM initialise at runtime config to fix build error

Co-authored-by: Tristan Roberts <tristan.roberts@paperasteroid.com>