### PR TITLE
Upgrade to ACME4J 5

### DIFF
--- a/acme/build.gradle
+++ b/acme/build.gradle
@@ -23,3 +23,9 @@ dependencies {
         implementation(libs.bouncycastle.bcprov)
     }
 }
+
+tasks.withType(Test).configureEach {
+    if (System.getenv("TESTCONTAINERS_HOST_OVERRIDE")) {
+        systemProperty "jdk.internal.httpclient.disableHostnameVerification", "true"
+    }
+}

--- a/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
+++ b/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,6 @@ import org.shredzone.acme4j.challenge.Dns01Challenge;
 import org.shredzone.acme4j.challenge.Http01Challenge;
 import org.shredzone.acme4j.challenge.TlsAlpn01Challenge;
 import org.shredzone.acme4j.exception.AcmeException;
-import org.shredzone.acme4j.exception.AcmeRetryAfterException;
 import org.shredzone.acme4j.util.CSRBuilder;
 import org.shredzone.acme4j.util.CertificateUtils;
 import org.shredzone.acme4j.util.KeyPairUtils;
@@ -262,7 +261,8 @@ public class AcmeService {
                 if (retryAttempt > 0) {
                     if (retryAfter.get() < Instant.now().toEpochMilli()) {
                         try {
-                            order.update();
+                            Optional<Instant> retryAfterInstant = order.fetch();
+                            retryAfterInstant.ifPresent(instant -> retryAfter.set(instant.toEpochMilli()));
                             Status status = order.getStatus();
                             if (status == Status.INVALID) {
                                 throw new AcmeRuntimeException("ACME certificate order failed. The certificate order was invalid: " + order.getError());
@@ -303,8 +303,6 @@ public class AcmeService {
                                     LOG.debug("Waiting on valid order status. Attempt : {}", retryAttempt);
                                 }
                             }
-                        } catch (AcmeRetryAfterException e) {
-                            retryAfter.set(e.getRetryAfter().toEpochMilli());
                         } catch (AcmeException e) {
                             throw new AcmeRuntimeException("ACME certificate order failed. Failed to update the certificate order. Reason : " + e.getMessage());
                         }
@@ -469,7 +467,7 @@ public class AcmeService {
                         throw new AcmeRuntimeException("ACME certificate order failed. Challenge of type " + challenge.getType() + " failed. With error : " + challenge.getError() + ", for domain" + auth.getIdentifier() + " ... Giving up.");
                     } else {
                         try {
-                            challenge.update();
+                            challenge.fetch();
                         } catch (AcmeException e) {
                             if (LOG.isWarnEnabled()) {
                                 LOG.warn("ACME certificate order failed. Challenge of type {} failed.", challenge.getType(), e);

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeBaseSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeBaseSpec.groovy
@@ -79,7 +79,7 @@ abstract class AcmeBaseSpec extends Specification {
         KeyPair keyPair = getAccountKeypair()
         getDomainKeypair()
 
-        acmeServerUrl = "https://localhost:${certServerContainer.getMappedPort(expectedPebbleServerPort)}/dir"
+        acmeServerUrl = "https://${certServerContainer.getHost()}:${certServerContainer.getMappedPort(expectedPebbleServerPort)}/dir"
         // Create an account with the acme server
         Session session = new Session(acmeServerUrl)
         SSLContext.setDefault(trustAllSslContext())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 micronaut = "5.0.0-M26"
 micronaut-platform = "4.10.7"
-managed-acme4j = "3.5.1"
+managed-acme4j = "5.1.0"
 micronaut-serde = "3.0.0-M8"
 micronaut-validation = "5.0.0-M2"
 micronaut-gradle-plugin = "4.6.2"


### PR DESCRIPTION
## Summary

- Upgrade the managed ACME4J dependency to 5.1.0.
- Adapt ACME order polling to ACME4J 5's fetch API and retry-after return value.
- Update Pebble/Testcontainers tests to use the mapped container host in local Docker environments.

## Verification

- ./gradlew :micronaut-acme:compileJava :micronaut-acme:compileTestGroovy --continue
- ./gradlew :micronaut-acme:test --tests 'io.micronaut.acme.AcmeCertRefresherTaskSetsTimeoutSpec'
- ./gradlew :micronaut-acme:test --tests '*challenges*'
- ./gradlew :micronaut-acme:check
- ./gradlew spotlessApply check -q -x japiCmp -x checkVersionCatalogCompatibility

Resolves https://github.com/micronaut-projects/micronaut-acme/issues/574
