### PR TITLE
Fix ACME refresh schedule duration defaults

### DIFF
--- a/acme/src/main/java/io/micronaut/acme/background/AcmeCertRefresherTask.java
+++ b/acme/src/main/java/io/micronaut/acme/background/AcmeCertRefresherTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,8 +60,8 @@ public final class AcmeCertRefresherTask {
      * @throws AcmeException if any issues occur during certificate renewal
      */
     @Scheduled(
-            fixedDelay = "${acme.refresh.frequency:24h}",
-            initialDelay = "${acme.refresh.delay:24h}")
+            fixedDelay = "${acme.refresh.frequency:PT24H}",
+            initialDelay = "${acme.refresh.delay:PT24H}")
     void backgroundRenewal() throws AcmeException {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Running background/scheduled renewal process");

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskUnitSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskUnitSpec.groovy
@@ -2,6 +2,8 @@ package io.micronaut.acme
 
 import io.micronaut.acme.background.AcmeCertRefresherTask
 import io.micronaut.acme.services.AcmeService
+import io.micronaut.context.ApplicationContext
+import io.micronaut.scheduling.annotation.Scheduled
 import io.micronaut.runtime.EmbeddedApplication
 import io.micronaut.runtime.event.ApplicationStartupEvent
 import io.micronaut.runtime.exceptions.ApplicationStartupException
@@ -15,6 +17,41 @@ import java.time.Duration
 
 @Stepwise
 class AcmeCertRefresherTaskUnitSpec extends Specification {
+
+    def "default refresh schedule uses ISO-8601 durations"() {
+        given:
+            def scheduled = AcmeCertRefresherTask.getDeclaredMethod("backgroundRenewal").getAnnotation(Scheduled)
+
+        expect:
+            scheduled.fixedDelay() == '${acme.refresh.frequency:PT24H}'
+            scheduled.initialDelay() == '${acme.refresh.delay:PT24H}'
+    }
+
+    def "context starts with default refresh schedule"() {
+        given:
+            ApplicationContext applicationContext = null
+            File temporaryFolder = File.createTempDir()
+
+        when:
+            applicationContext = ApplicationContext.builder([
+                    "acme.enabled": true,
+                    "acme.tos-agree": true,
+                    "acme.domains": ["example.com"],
+                    "acme.account-key": "test-account-key",
+                    "acme.domain-key": "test-domain-key",
+                    "acme.cert-location": temporaryFolder.toString(),
+                    "acme.acme-server": "https://localhost/acme",
+                    "micronaut.server.ssl.enabled": true
+            ]).start()
+
+        then:
+            noExceptionThrown()
+            applicationContext.getBean(AcmeCertRefresherTask)
+
+        cleanup:
+            applicationContext?.close()
+            temporaryFolder?.deleteDir()
+    }
 
     def "throw exception if TOS has not been accepted"() {
         given:

--- a/src/main/docs/guide/configuration.adoc
+++ b/src/main/docs/guide/configuration.adoc
@@ -21,8 +21,8 @@ acme:
       - stage.domain.com
       - test.domain.com
     refresh:
-        delay: 1m // <8>
-        frequency: 24h // <9>
+        delay: PT1M // <8>
+        frequency: PT24H // <9>
     domain-key: | // <10>
         -----BEGIN RSA PRIVATE KEY-----
         MIIEowIBAAKCAQEAi32GgrNvt5sYonmvFRs1lYMdUTsoFHz33knzsTvBRb+S1JCc
@@ -57,8 +57,8 @@ acme:
 <5> Agrees to the Terms of Service of the ACME provider. Default is `false`
 <6> Location to store the certificate on the server.
 <7> Domain name(s) for the certificate. Can be a 1 or many domains or even a wildcard domain.
-<8> How long to wait until the server starts up the ACME background process. Default is `24 hours`
-<9> How often the server will check for a new ACME cert and refresh it if needed. Default is `24 hours`
+<8> How long to wait until the server starts up the ACME background process. Default is `PT24H` (`24 hours`)
+<9> How often the server will check for a new ACME cert and refresh it if needed. Default is `PT24H` (`24 hours`)
 <10> Private key used to encrypt the certificate. Other options you can use here are `classpath:/path/to/key.pem` or `file:/path/to/key.pem`. It is advisable to not check this into source control as this is the secret to handle the domain encryption.
 <11> Private key used to when setting up your account with the ACME provider. Other options you can use here are `classpath:/path/to/key.pem` or `file:/path/to/key.pem`.  It is advisable to not check this into source control as this is your account identifier.
 <12> Url of the ACME server (ex. acme://letsencrypt.org/staging)


### PR DESCRIPTION
## Summary

- Use ISO-8601 duration defaults for the ACME refresh scheduler.
- Add coverage for the default schedule metadata and context startup.
- Update the guide refresh examples to use ISO-8601 durations.

## Verification

- ./gradlew :micronaut-acme:test --tests io.micronaut.acme.AcmeCertRefresherTaskUnitSpec -q
- ./gradlew spotlessCheck :micronaut-acme:compileJava :micronaut-acme:compileTestGroovy -q

Note: ./gradlew spotlessApply :micronaut-acme:check -q -x japiCmp -x checkVersionCatalogCompatibility was also attempted, but Docker/Pebble-backed ACME integration specs failed locally with AcmeNetworkException: Network error. The focused unit/context coverage passed.

Resolves https://github.com/micronaut-projects/micronaut-acme/issues/430
