### PR TITLE
Allow ACME account creation at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ the front runner for integration with Acme and is completely free.
 See the [stable](https://micronaut-projects.github.io/micronaut-acme/latest/guide) or [snapshot](https://micronaut-projects.github.io/micronaut-acme/snapshot/guide) documentation for more information.
 
 ## ACME Tooling ##
-Since ACME servers do require some pre setup support has been baked into the micronaut-cli found [here](https://github.com/micronaut-projects/micronaut-starter). Which can help you create keys, create/deactivate accounts, etc.
+Since ACME servers do require some pre setup support has been baked into the micronaut-cli found [here](https://github.com/micronaut-projects/micronaut-starter). It can help you create keys, create/deactivate accounts, etc.
+
+The Micronaut ACME runtime can also create or reuse an ACME account at startup from the configured account key, so deployed container images and native-image binaries do not need the Micronaut CLI available.
 
 ## Example Application ##
 
@@ -46,4 +48,3 @@ A release is performed with the following steps:
 1. Checkout from Github (e.g. `git clone git@github.com:micronaut/micronaut-acme.git`)
 2. `cd micronaut-acme`
 3. `./gradlew build`
-

--- a/acme/build.gradle
+++ b/acme/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
+    // Pebble's test certificate is issued for localhost, while remote Docker exposes it through the Testcontainers host.
     if (System.getenv("TESTCONTAINERS_HOST_OVERRIDE")) {
         systemProperty "jdk.internal.httpclient.disableHostnameVerification", "true"
     }

--- a/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
+++ b/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
@@ -244,10 +244,14 @@ public class AcmeService {
     }
 
     private Login doLogin(Session session, KeyPair accountKeyPair) throws AcmeException {
-        Login login = new AccountBuilder()
-                .onlyExisting()
-                .useKeyPair(accountKeyPair)
-                .createLogin(session);
+        AccountBuilder accountBuilder = new AccountBuilder()
+                .useKeyPair(accountKeyPair);
+        if (acmeConfiguration.isTosAgree()) {
+            accountBuilder.agreeToTermsOfService();
+        } else {
+            accountBuilder.onlyExisting();
+        }
+        Login login = accountBuilder.createLogin(session);
         return login;
     }
 

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeBaseSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeBaseSpec.groovy
@@ -80,15 +80,17 @@ abstract class AcmeBaseSpec extends Specification {
         getDomainKeypair()
 
         acmeServerUrl = "https://${certServerContainer.getHost()}:${certServerContainer.getMappedPort(expectedPebbleServerPort)}/dir"
-        // Create an account with the acme server
-        Session session = new Session(acmeServerUrl)
         SSLContext.setDefault(trustAllSslContext())
-        Account createNewAccount = new AccountBuilder()
-                .agreeToTermsOfService()
-                .addEmail("test@micronaut.io")
-                .useKeyPair(keyPair)
-                .create(session)
-        assert createNewAccount.status == Status.VALID
+        if (registerAccountBeforeStartup()) {
+            // Create an account with the acme server
+            Session session = new Session(acmeServerUrl)
+            Account createNewAccount = new AccountBuilder()
+                    .agreeToTermsOfService()
+                    .addEmail("test@micronaut.io")
+                    .useKeyPair(keyPair)
+                    .create(session)
+            assert createNewAccount.status == Status.VALID
+        }
 
         embeddedServer = ApplicationContext.run(EmbeddedServer,
                                                 getConfiguration(),
@@ -150,6 +152,10 @@ abstract class AcmeBaseSpec extends Specification {
         return [
             "PEBBLE_VA_ALWAYS_VALID": "1"
         ]
+    }
+
+    boolean registerAccountBeforeStartup() {
+        true
     }
 
     Map<String, Object> getConfiguration() {

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskCreatesAccountSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskCreatesAccountSpec.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.acme
+
+import spock.lang.Stepwise
+import spock.util.concurrent.PollingConditions
+
+@Stepwise
+class AcmeCertRefresherTaskCreatesAccountSpec extends AcmeBaseSpec {
+
+    @Override
+    boolean registerAccountBeforeStartup() {
+        false
+    }
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.getConfiguration() << [
+                "acme.domains": EXPECTED_DOMAIN,
+        ]
+    }
+
+    def "get new certificate using account created on startup"() {
+        expect:
+        new PollingConditions(timeout: 30).eventually {
+            certFolder.list().length == 2
+            certFolder.list().contains("domain.crt")
+            certFolder.list().contains("domain.csr")
+        }
+    }
+}

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskSetsTimeoutSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskSetsTimeoutSpec.groovy
@@ -131,6 +131,38 @@ class AcmeCertRefresherTaskSetsTimeoutSpec extends Specification {
         new ActualSlowServerConfig(slowAuthorization: true) | _
     }
 
+    def "requests account creation during startup when configured account key is not pre-registered"() {
+        given: "we have all the ports we could ever need"
+        expectedHttpPort = SocketUtils.findAvailableTcpPort()
+        expectedSecurePort = SocketUtils.findAvailableTcpPort()
+        expectedAcmePort = SocketUtils.findAvailableTcpPort()
+        acmeServerUrl = "http://localhost:$expectedAcmePort/acme/dir"
+
+        and: "we have a slow acme server that times out after account registration"
+        EmbeddedServer mockAcmeServer = ApplicationContext.builder(['micronaut.server.port': expectedAcmePort])
+                .environments("test")
+                .packages(SlowAcmeServer.getPackage().getName(), AcmeCertRefresherTaskSetsTimeoutSpec.getPackage().getName())
+                .run(EmbeddedServer)
+        SlowAcmeServer slowAcmeServer = mockAcmeServer.getApplicationContext().getBean(SlowAcmeServer.class)
+        slowAcmeServer.setAcmeServerUrl(acmeServerUrl)
+        slowAcmeServer.setSlowServerConfig(new ActualSlowServerConfig(slowOrdering: true))
+
+        when: "the application starts without an account pre-registration step"
+        EmbeddedServer appServer = ApplicationContext.run(EmbeddedServer,
+                                                          getConfiguration() << ["acme.timeout": "${networkTimeoutInSecs}s"],
+                                                          "test")
+
+        then: "the account request can create the account for the configured account key"
+        thrown(ApplicationStartupException)
+        slowAcmeServer.signupPayload.get() != null
+        slowAcmeServer.signupPayload.get().termsOfServiceAgreed == true
+        !slowAcmeServer.signupPayload.get().containsKey("onlyReturnExisting")
+
+        cleanup:
+        appServer?.stop()
+        mockAcmeServer?.stop()
+    }
+
     class ActualSlowServerConfig implements SlowServerConfig {
 
         boolean slowSignup

--- a/acme/src/test/groovy/io/micronaut/mock/slow/SlowAcmeServer.groovy
+++ b/acme/src/test/groovy/io/micronaut/mock/slow/SlowAcmeServer.groovy
@@ -1,7 +1,9 @@
 package io.micronaut.mock.slow
 
+import groovy.json.JsonSlurper
 import io.micronaut.context.annotation.Requires
 import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Consumes
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
@@ -9,8 +11,10 @@ import io.micronaut.http.annotation.Head
 import io.micronaut.http.annotation.Post
 import io.netty.handler.ssl.util.SelfSignedCertificate
 
+import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 @Requires(env = "test")
 @Controller('/acme')
@@ -41,6 +45,7 @@ class SlowAcmeServer {
     }
 
     AtomicInteger requestCounter = new AtomicInteger()
+    AtomicReference<Map> signupPayload = new AtomicReference<>()
 
     @Consumes("application/jose+json")
     @Post('/your-order')
@@ -96,7 +101,8 @@ class SlowAcmeServer {
 
     @Consumes("application/jose+json")
     @Post('/sign-me-up')
-    HttpResponse<String> signmeup() {
+    HttpResponse<String> signmeup(@Body String requestBody) {
+        signupPayload.set(readJosePayload(requestBody))
         if (slowServerConfig.isSlowSignup()) {
             doItSlowly(slowServerConfig.duration)
         }
@@ -207,6 +213,20 @@ class SlowAcmeServer {
                   "revokeCert": "$acmeServerUrl/revoke-cert"
                 }
             """
+    }
+
+    private static Map readJosePayload(String requestBody) {
+        if (!requestBody) {
+            return Collections.emptyMap()
+        }
+        def jose = new JsonSlurper().parseText(requestBody) as Map
+        String payload = jose.payload
+        if (!payload) {
+            return Collections.emptyMap()
+        }
+        String paddedPayload = payload + ("=" * ((4 - payload.length() % 4) % 4))
+        byte[] decoded = Base64.getUrlDecoder().decode(paddedPayload)
+        return new JsonSlurper().parseText(new String(decoded, StandardCharsets.UTF_8)) as Map
     }
 
     private void doItSlowly(Duration sleepTime) {

--- a/src/main/docs/guide/cli.adoc
+++ b/src/main/docs/guide/cli.adoc
@@ -1,2 +1,3 @@
 To be able to secure your application using ACME there will be a few setup steps necessary before you can start using
 the new certificates. Support for ACME and this setup has been baked into micronaut-starter (https://github.com/micronaut-projects/micronaut-starter).
+These CLI commands are optional provisioning helpers. Applications deployed from a container image or released native-image binary can also create or reuse the ACME account at startup from the configured account key.

--- a/src/main/docs/guide/cli/usage.adoc
+++ b/src/main/docs/guide/cli/usage.adoc
@@ -58,7 +58,17 @@ Creates an keypair for use with ACME integration
 Creates a new account for a given ACME provider. This command will either create a new account keypair for you or you can pass
 the account keypair that you have generated using the `mn create-key` or via `openssl` or other means in as a parameter.
 
-https://certbot.eff.org/[Certbot] or many of the other tools out there can also accomplish this step if you dont want to use this tool.
+You do not need this command at deployment time if your application has an account key. When `acme.tos-agree` is set to `true`, Micronaut ACME can create or reuse the ACME account at startup with the configured `acme.account-key`. This is useful for container images and released native-image binaries that do not include the Micronaut CLI.
+
+[configuration]
+----
+acme:
+    tos-agree: true
+    account-key: file:/etc/acme/account-key.pem
+    acme-server: acme://letsencrypt.org/staging
+----
+
+The `mn create-acme-account` command remains useful when you want account registration as a separate provisioning step before the application starts.
 
 Usage:
 

--- a/src/main/docs/guide/configuration.adoc
+++ b/src/main/docs/guide/configuration.adoc
@@ -60,7 +60,7 @@ acme:
 <8> How long to wait until the server starts up the ACME background process. Default is `24 hours`
 <9> How often the server will check for a new ACME cert and refresh it if needed. Default is `24 hours`
 <10> Private key used to encrypt the certificate. Other options you can use here are `classpath:/path/to/key.pem` or `file:/path/to/key.pem`. It is advisable to not check this into source control as this is the secret to handle the domain encryption.
-<11> Private key used to when setting up your account with the ACME provider. Other options you can use here are `classpath:/path/to/key.pem` or `file:/path/to/key.pem`.  It is advisable to not check this into source control as this is your account identifier.
+<11> Private key used when setting up your account with the ACME provider. Other options you can use here are `classpath:/path/to/key.pem` or `file:/path/to/key.pem`. When `acme.tos-agree` is `true`, Micronaut ACME can create or reuse the ACME account with this key at startup. It is advisable to not check this into source control as this is your account identifier.
 <12> Url of the ACME server (ex. acme://letsencrypt.org/staging)
 <13> Time to wait in between polling order status of the ACME server. Default is `3 seconds`
 <14> Number of times to poll an order status of the ACME server. Default is `10`


### PR DESCRIPTION
## Summary
- create or reuse the configured ACME account at startup when terms of service are accepted
- document deployment without the Micronaut CLI account creation command
- add regression coverage for startup-created accounts and remote Testcontainers Pebble access

## Verification
- ./gradlew -q :micronaut-acme:test
- ./gradlew spotlessApply check -q -x japiCmp -x checkVersionCatalogCompatibility
- ./gradlew -q docs
- ./gradlew -q spotlessCheck

Resolves https://github.com/micronaut-projects/micronaut-acme/issues/157
