### PR TITLE
Retry ACME login and order requests

### DIFF
--- a/acme/build.gradle
+++ b/acme/build.gradle
@@ -22,6 +22,8 @@ dependencies {
         // Force Bouncy Castle >= 1.84 to fix GHSA-wg6q-6289-32hp and GHSA-c3fc-8qff-9hwx
         implementation(libs.bouncycastle.bcpkix)
         implementation(libs.bouncycastle.bcprov)
+        // Force Netty HTTP codec >= 4.2.13.Final to fix GHSA-v8h7-rr48-vmmv
+        implementation(libs.netty.codec.http)
     }
 }
 

--- a/acme/build.gradle
+++ b/acme/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     annotationProcessor(mnValidation.micronaut.validation.processor)
     implementation(mnValidation.micronaut.validation)
     implementation mn.micronaut.http
+    implementation mn.micronaut.retry
     implementation mn.micronaut.http.server
     implementation mn.micronaut.http.server.netty
     implementation libs.managed.acme4j.client

--- a/acme/src/main/java/io/micronaut/acme/AcmeConfiguration.java
+++ b/acme/src/main/java/io/micronaut/acme/AcmeConfiguration.java
@@ -18,6 +18,7 @@ package io.micronaut.acme;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import org.jspecify.annotations.NonNull;
 import io.micronaut.core.util.Toggleable;
+import io.micronaut.retry.RetryPolicy;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -54,6 +55,7 @@ public class AcmeConfiguration implements Toggleable {
     private Integer httpChallengeServerPort = 9999;
     private OrderConfiguration order = new OrderConfiguration();
     private AuthConfiguration auth = new AuthConfiguration();
+    private RetryConfiguration requestRetry = new RetryConfiguration();
 
     /**
      * If acme certificate background and setup process should be enabled.
@@ -159,6 +161,24 @@ public class AcmeConfiguration implements Toggleable {
      */
     public void setAuth(AuthConfiguration auth) {
         this.auth = auth;
+    }
+
+    /**
+     * Gets retry configuration for login and new order requests.
+     *
+     * @return retry configuration for login and new order requests
+     */
+    public RetryConfiguration getRequestRetry() {
+        return requestRetry;
+    }
+
+    /**
+     * Sets retry configuration for login and new order requests.
+     *
+     * @param requestRetry retry configuration for login and new order requests
+     */
+    public void setRequestRetry(RetryConfiguration requestRetry) {
+        this.requestRetry = requestRetry;
     }
 
     /**
@@ -368,5 +388,107 @@ public class AcmeConfiguration implements Toggleable {
      */
     @ConfigurationProperties("auth")
     public static class AuthConfiguration extends AbstractConfiguration {
+    }
+
+    /**
+     * Allows configuration of ACME retry policy.
+     */
+    @ConfigurationProperties("request-retry")
+    public static class RetryConfiguration {
+        private int attempts = RetryPolicy.DEFAULT_MAX_ATTEMPTS;
+        private Duration delay = RetryPolicy.DEFAULT_DELAY;
+        private Duration maxDelay;
+        private double multiplier = RetryPolicy.DEFAULT_MULTIPLIER;
+        private double jitter = RetryPolicy.DEFAULT_JITTER;
+
+        /**
+         * Gets maximum retry attempts.
+         *
+         * @return maximum retry attempts
+         */
+        public int getAttempts() {
+            return attempts;
+        }
+
+        /**
+         * Sets maximum retry attempts.
+         *
+         * @param attempts maximum retry attempts
+         */
+        public void setAttempts(int attempts) {
+            this.attempts = attempts;
+        }
+
+        /**
+         * Gets delay between retry attempts.
+         *
+         * @return delay between retry attempts
+         */
+        public Duration getDelay() {
+            return delay;
+        }
+
+        /**
+         * Sets delay between retry attempts.
+         *
+         * @param delay delay between retry attempts
+         */
+        public void setDelay(Duration delay) {
+            this.delay = delay;
+        }
+
+        /**
+         * Gets maximum overall retry delay.
+         *
+         * @return maximum overall retry delay
+         */
+        public Duration getMaxDelay() {
+            return maxDelay;
+        }
+
+        /**
+         * Sets maximum overall retry delay.
+         *
+         * @param maxDelay maximum overall retry delay
+         */
+        public void setMaxDelay(Duration maxDelay) {
+            this.maxDelay = maxDelay;
+        }
+
+        /**
+         * Gets retry delay multiplier.
+         *
+         * @return retry delay multiplier
+         */
+        public double getMultiplier() {
+            return multiplier;
+        }
+
+        /**
+         * Sets retry delay multiplier.
+         *
+         * @param multiplier retry delay multiplier
+         */
+        public void setMultiplier(double multiplier) {
+            this.multiplier = multiplier;
+        }
+
+        /**
+         * Gets retry jitter factor.
+         *
+         * @return retry jitter factor
+         */
+        public double getJitter() {
+            return jitter;
+        }
+
+        /**
+         * Sets retry jitter factor.
+         *
+         * @param jitter retry jitter factor
+         */
+        public void setJitter(double jitter) {
+            this.jitter = jitter;
+        }
     }
 }

--- a/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
+++ b/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
@@ -23,7 +23,11 @@ import io.micronaut.context.event.ApplicationEventPublisher;
 import org.jspecify.annotations.NonNull;
 import io.micronaut.core.io.IOUtils;
 import io.micronaut.core.io.ResourceResolver;
+import io.micronaut.retry.RetryOperations;
+import io.micronaut.retry.RetryOperationsFactory;
+import io.micronaut.retry.RetryPolicy;
 import io.micronaut.scheduling.TaskScheduler;
+import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import org.shredzone.acme4j.AccountBuilder;
@@ -38,6 +42,7 @@ import org.shredzone.acme4j.challenge.Dns01Challenge;
 import org.shredzone.acme4j.challenge.Http01Challenge;
 import org.shredzone.acme4j.challenge.TlsAlpn01Challenge;
 import org.shredzone.acme4j.exception.AcmeException;
+import org.shredzone.acme4j.exception.AcmeNetworkException;
 import org.shredzone.acme4j.util.CSRBuilder;
 import org.shredzone.acme4j.util.CertificateUtils;
 import org.shredzone.acme4j.util.KeyPairUtils;
@@ -104,6 +109,7 @@ public class AcmeService {
     private final Duration orderPause;
     private final Duration timeout;
     private final DnsChallengeSolver dnsChallengeSolver;
+    private RetryOperations requestRetryOperations;
 
     private ApplicationEventPublisher eventPublisher;
 
@@ -133,6 +139,16 @@ public class AcmeService {
         this.resourceResolver = resourceResolver;
         this.taskScheduler = taskScheduler;
         this.dnsChallengeSolver = dnsChallengeSolver;
+    }
+
+    /**
+     * Sets the retry operations factory.
+     *
+     * @param retryOperationsFactory Retry Operations Factory
+     */
+    @Inject
+    void setRetryOperationsFactory(RetryOperationsFactory retryOperationsFactory) {
+        this.requestRetryOperations = retryOperationsFactory.createRetryOperations(createRequestRetryPolicy(acmeConfiguration.getRequestRetry()));
     }
 
     /**
@@ -204,8 +220,8 @@ public class AcmeService {
             return;
         }
 
-        Login login = doLogin(session, accountKeyPair);
-        Order order = createOrder(domains, login);
+        Login login = withOrderRequestRetries(() -> doLogin(session, accountKeyPair));
+        Order order = withOrderRequestRetries(() -> createOrder(domains, login));
         for (Authorization auth : order.getAuthorizations()) {
             try {
                 authorize(auth);
@@ -249,6 +265,38 @@ public class AcmeService {
                 .useKeyPair(accountKeyPair)
                 .createLogin(session);
         return login;
+    }
+
+    private RetryPolicy createRequestRetryPolicy(AcmeConfiguration.RetryConfiguration retryConfiguration) {
+        return RetryPolicy.builder()
+                .maxAttempts(retryConfiguration.getAttempts())
+                .delay(retryConfiguration.getDelay())
+                .maxDelay(retryConfiguration.getMaxDelay())
+                .multiplier(retryConfiguration.getMultiplier())
+                .jitter(retryConfiguration.getJitter())
+                .capturedException(RetryableAcmeNetworkException.class)
+                .build();
+    }
+
+    private <T> T withOrderRequestRetries(AcmeRequest<T> request) throws AcmeException {
+        if (requestRetryOperations == null) {
+            return request.execute();
+        }
+        try {
+            return requestRetryOperations.execute(() -> executeAcmeRequest(request));
+        } catch (AcmeRequestRuntimeException e) {
+            throw e.getAcmeException();
+        }
+    }
+
+    private <T> T executeAcmeRequest(AcmeRequest<T> request) {
+        try {
+            return request.execute();
+        } catch (AcmeNetworkException e) {
+            throw new RetryableAcmeNetworkException(e);
+        } catch (AcmeException e) {
+            throw new NonRetryableAcmeException(e);
+        }
     }
 
     @SuppressWarnings("java:S3776")
@@ -568,6 +616,38 @@ public class AcmeService {
 
         void cancel() {
             future.cancel(false);
+        }
+    }
+
+    private interface AcmeRequest<T> {
+        T execute() throws AcmeException;
+    }
+
+    private abstract static class AcmeRequestRuntimeException extends RuntimeException {
+
+        private final AcmeException acmeException;
+
+        AcmeRequestRuntimeException(AcmeException acmeException) {
+            super(acmeException);
+            this.acmeException = acmeException;
+        }
+
+        AcmeException getAcmeException() {
+            return acmeException;
+        }
+    }
+
+    private static final class RetryableAcmeNetworkException extends AcmeRequestRuntimeException {
+
+        RetryableAcmeNetworkException(AcmeNetworkException acmeException) {
+            super(acmeException);
+        }
+    }
+
+    private static final class NonRetryableAcmeException extends AcmeRequestRuntimeException {
+
+        NonRetryableAcmeException(AcmeException acmeException) {
+            super(acmeException);
         }
     }
 }

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskSetsTimeoutSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskSetsTimeoutSpec.groovy
@@ -19,6 +19,7 @@ import java.time.Duration
 class AcmeCertRefresherTaskSetsTimeoutSpec extends Specification {
 
     public static final String EXPECTED_DOMAIN = "localhost"
+    private static final int NETWORK_TIMEOUT_IN_MILLIS = 1000
 
     @Shared
     @AutoCleanup("deleteDir")
@@ -107,7 +108,13 @@ class AcmeCertRefresherTaskSetsTimeoutSpec extends Specification {
 
         when: "we configure network timeouts"
         EmbeddedServer appServer = ApplicationContext.run(EmbeddedServer,
-                                                          getConfiguration() << ["acme.timeout": "${networkTimeoutInSecs}s"],
+                                                          getConfiguration() << [
+                                                                  "acme.timeout"               : "${networkTimeoutInSecs}s",
+                                                                  "acme.order.pause"           : "100ms",
+                                                                  "acme.order.refresh-attempts": 2,
+                                                                  "acme.request-retry.attempts": 2,
+                                                                  "acme.request-retry.delay": "100ms",
+                                                          ],
                                                           "test")
 
         then: "we get network errors b/c of the timeout"
@@ -131,15 +138,78 @@ class AcmeCertRefresherTaskSetsTimeoutSpec extends Specification {
         new ActualSlowServerConfig(slowAuthorization: true) | _
     }
 
+    def "retries timed out #description requests"(String description,
+                                                  int slowSignupAttempts,
+                                                  int slowOrderingAttempts,
+                                                  int expectedSignupRequests,
+                                                  int expectedOrderRequests) {
+        given: "we have all the ports we could ever need"
+        expectedHttpPort = SocketUtils.findAvailableTcpPort()
+        expectedSecurePort = SocketUtils.findAvailableTcpPort()
+        expectedAcmePort = SocketUtils.findAvailableTcpPort()
+        acmeServerUrl = "http://localhost:$expectedAcmePort/acme/dir"
+        SlowServerConfig config = new ActualSlowServerConfig(
+                slowSignupAttempts: slowSignupAttempts,
+                slowOrderingAttempts: slowOrderingAttempts,
+                duration: Duration.ofMillis(NETWORK_TIMEOUT_IN_MILLIS + 100)
+        )
+
+        and: "we have an acme server with one transiently slow endpoint"
+        EmbeddedServer mockAcmeServer = ApplicationContext.builder(['micronaut.server.port': expectedAcmePort])
+                .environments("test")
+                .packages(SlowAcmeServer.getPackage().getName(), AcmeCertRefresherTaskSetsTimeoutSpec.getPackage().getName())
+                .run(EmbeddedServer)
+        SlowAcmeServer slowAcmeServer = mockAcmeServer.getApplicationContext().getBean(SlowAcmeServer.class)
+        slowAcmeServer.setAcmeServerUrl(acmeServerUrl)
+        slowAcmeServer.setSlowServerConfig(config)
+
+        when: "we configure network timeouts and retries"
+        EmbeddedServer appServer = ApplicationContext.run(EmbeddedServer,
+                                                          getConfiguration() << [
+                                                                  "acme.timeout"               : "${NETWORK_TIMEOUT_IN_MILLIS}ms",
+                                                                  "acme.order.pause"           : "${NETWORK_TIMEOUT_IN_MILLIS}ms",
+                                                                  "acme.order.refresh-attempts": 3,
+                                                                  "acme.request-retry.attempts": 2,
+                                                                  "acme.request-retry.delay": "100ms",
+                                                          ],
+                                                          "test")
+
+        then: "startup succeeds after a retry"
+        appServer.running
+        slowAcmeServer.signupRequestCounter.get() == expectedSignupRequests
+        slowAcmeServer.orderRequestCounter.get() == expectedOrderRequests
+
+        cleanup:
+        appServer?.stop()
+        mockAcmeServer?.stop()
+
+        where:
+        description | slowSignupAttempts | slowOrderingAttempts | expectedSignupRequests | expectedOrderRequests
+        "login"     | 1                   | 0                    | 2                      | 1
+        "order"     | 0                   | 1                    | 1                      | 2
+    }
+
     class ActualSlowServerConfig implements SlowServerConfig {
 
         boolean slowSignup
         boolean slowOrdering
         boolean slowAuthorization
+        int slowSignupAttempts
+        int slowOrderingAttempts
         Duration duration = Duration.ofSeconds(networkTimeoutInSecs + 2)
 
         String toString() {
             "slowSignup: $slowSignup, slowOrdering: $slowOrdering, slowAuthorization: $slowAuthorization, duration: $duration"
+        }
+
+        @Override
+        int slowSignupAttempts() {
+            slowSignup ? Integer.MAX_VALUE : slowSignupAttempts
+        }
+
+        @Override
+        int slowOrderingAttempts() {
+            slowOrdering ? Integer.MAX_VALUE : slowOrderingAttempts
         }
     }
 

--- a/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskSetsTimeoutSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/AcmeCertRefresherTaskSetsTimeoutSpec.groovy
@@ -127,15 +127,19 @@ class AcmeCertRefresherTaskSetsTimeoutSpec extends Specification {
         rootEx instanceof HttpTimeoutException
         rootEx.message == "request timed out"
 
+        slowAcmeServer.signupRequestCounter.get() == expectedSignupRequests
+        slowAcmeServer.orderRequestCounter.get() == expectedOrderRequests
+        slowAcmeServer.authorizationRequestCounter.get() == expectedAuthorizationRequests
+
         cleanup:
         appServer?.stop()
         mockAcmeServer?.stop()
 
         where:
-        config                                              | _
-        new ActualSlowServerConfig(slowSignup: true)        | _
-        new ActualSlowServerConfig(slowOrdering: true)      | _
-        new ActualSlowServerConfig(slowAuthorization: true) | _
+        config                                              | expectedSignupRequests | expectedOrderRequests | expectedAuthorizationRequests
+        new ActualSlowServerConfig(slowSignup: true)        | 3                      | 0                     | 0
+        new ActualSlowServerConfig(slowOrdering: true)      | 1                      | 3                     | 0
+        new ActualSlowServerConfig(slowAuthorization: true) | 1                      | 1                     | 1
     }
 
     def "retries timed out #description requests"(String description,
@@ -189,11 +193,79 @@ class AcmeCertRefresherTaskSetsTimeoutSpec extends Specification {
         "order"     | 0                   | 1                    | 1                      | 2
     }
 
+    def "binds request retry configuration"() {
+        given:
+        expectedHttpPort = SocketUtils.findAvailableTcpPort()
+        expectedSecurePort = SocketUtils.findAvailableTcpPort()
+        expectedAcmePort = SocketUtils.findAvailableTcpPort()
+        acmeServerUrl = "http://localhost:$expectedAcmePort/acme/dir"
+
+        ApplicationContext context = ApplicationContext.run(getConfiguration() << [
+                "acme.request-retry.attempts"  : 4,
+                "acme.request-retry.delay"     : "200ms",
+                "acme.request-retry.max-delay" : "2s",
+                "acme.request-retry.multiplier": 1.5,
+                "acme.request-retry.jitter"    : 0.25,
+        ], "test")
+
+        when:
+        AcmeConfiguration.RetryConfiguration requestRetry = context.getBean(AcmeConfiguration).requestRetry
+
+        then:
+        requestRetry.attempts == 4
+        requestRetry.delay == Duration.ofMillis(200)
+        requestRetry.maxDelay == Duration.ofSeconds(2)
+        requestRetry.multiplier == 1.5d
+        requestRetry.jitter == 0.25d
+
+        cleanup:
+        context?.close()
+    }
+
+    def "does not retry non-network order failures"() {
+        given: "we have all the ports we could ever need"
+        expectedHttpPort = SocketUtils.findAvailableTcpPort()
+        expectedSecurePort = SocketUtils.findAvailableTcpPort()
+        expectedAcmePort = SocketUtils.findAvailableTcpPort()
+        acmeServerUrl = "http://localhost:$expectedAcmePort/acme/dir"
+        SlowServerConfig config = new ActualSlowServerConfig(failOrdering: true)
+
+        and: "we have an acme server that rejects new orders"
+        EmbeddedServer mockAcmeServer = ApplicationContext.builder(['micronaut.server.port': expectedAcmePort])
+                .environments("test")
+                .packages(SlowAcmeServer.getPackage().getName(), AcmeCertRefresherTaskSetsTimeoutSpec.getPackage().getName())
+                .run(EmbeddedServer)
+        SlowAcmeServer slowAcmeServer = mockAcmeServer.getApplicationContext().getBean(SlowAcmeServer.class)
+        slowAcmeServer.setAcmeServerUrl(acmeServerUrl)
+        slowAcmeServer.setSlowServerConfig(config)
+
+        when: "we configure request retries"
+        EmbeddedServer appServer = ApplicationContext.run(EmbeddedServer,
+                                                          getConfiguration() << [
+                                                                  "acme.timeout"               : "${NETWORK_TIMEOUT_IN_MILLIS}ms",
+                                                                  "acme.order.pause"           : "${NETWORK_TIMEOUT_IN_MILLIS}ms",
+                                                                  "acme.order.refresh-attempts": 3,
+                                                                  "acme.request-retry.attempts": 3,
+                                                                  "acme.request-retry.delay"   : "100ms",
+                                                          ],
+                                                          "test")
+
+        then: "the non-network failure is not retried"
+        thrown(ApplicationStartupException)
+        slowAcmeServer.signupRequestCounter.get() == 1
+        slowAcmeServer.orderRequestCounter.get() == 1
+
+        cleanup:
+        appServer?.stop()
+        mockAcmeServer?.stop()
+    }
+
     class ActualSlowServerConfig implements SlowServerConfig {
 
         boolean slowSignup
         boolean slowOrdering
         boolean slowAuthorization
+        boolean failOrdering
         int slowSignupAttempts
         int slowOrderingAttempts
         Duration duration = Duration.ofSeconds(networkTimeoutInSecs + 2)

--- a/acme/src/test/groovy/io/micronaut/mock/slow/SlowAcmeServer.groovy
+++ b/acme/src/test/groovy/io/micronaut/mock/slow/SlowAcmeServer.groovy
@@ -41,6 +41,8 @@ class SlowAcmeServer {
     }
 
     AtomicInteger requestCounter = new AtomicInteger()
+    AtomicInteger signupRequestCounter = new AtomicInteger()
+    AtomicInteger orderRequestCounter = new AtomicInteger()
 
     @Consumes("application/jose+json")
     @Post('/your-order')
@@ -97,7 +99,7 @@ class SlowAcmeServer {
     @Consumes("application/jose+json")
     @Post('/sign-me-up')
     HttpResponse<String> signmeup() {
-        if (slowServerConfig.isSlowSignup()) {
+        if (signupRequestCounter.getAndIncrement() < slowServerConfig.slowSignupAttempts()) {
             doItSlowly(slowServerConfig.duration)
         }
         return HttpResponse.ok(
@@ -135,7 +137,7 @@ class SlowAcmeServer {
     @Consumes("application/jose+json")
     @Post('/order-plz')
     HttpResponse<String> order() {
-        if (slowServerConfig.isSlowOrdering()) {
+        if (orderRequestCounter.getAndIncrement() < slowServerConfig.slowOrderingAttempts()) {
             doItSlowly(slowServerConfig.duration)
         }
         return HttpResponse.ok(

--- a/acme/src/test/groovy/io/micronaut/mock/slow/SlowAcmeServer.groovy
+++ b/acme/src/test/groovy/io/micronaut/mock/slow/SlowAcmeServer.groovy
@@ -43,6 +43,7 @@ class SlowAcmeServer {
     AtomicInteger requestCounter = new AtomicInteger()
     AtomicInteger signupRequestCounter = new AtomicInteger()
     AtomicInteger orderRequestCounter = new AtomicInteger()
+    AtomicInteger authorizationRequestCounter = new AtomicInteger()
 
     @Consumes("application/jose+json")
     @Post('/your-order')
@@ -140,6 +141,9 @@ class SlowAcmeServer {
         if (orderRequestCounter.getAndIncrement() < slowServerConfig.slowOrderingAttempts()) {
             doItSlowly(slowServerConfig.duration)
         }
+        if (slowServerConfig.isFailOrdering()) {
+            return HttpResponse.serverError("order failed")
+        }
         return HttpResponse.ok(
                 """
                 {
@@ -163,7 +167,7 @@ class SlowAcmeServer {
     @Consumes("application/jose+json")
     @Post('/authz')
     String authz() {
-        if (slowServerConfig.isSlowAuthorization()) {
+        if (authorizationRequestCounter.getAndIncrement() < slowServerConfig.slowAuthorizationAttempts()) {
             doItSlowly(slowServerConfig.duration)
         }
         return """

--- a/acme/src/test/groovy/io/micronaut/mock/slow/SlowServerConfig.groovy
+++ b/acme/src/test/groovy/io/micronaut/mock/slow/SlowServerConfig.groovy
@@ -6,6 +6,7 @@ interface SlowServerConfig {
     boolean isSlowSignup()
     boolean isSlowAuthorization()
     boolean isSlowOrdering()
+    boolean isFailOrdering()
     Duration getDuration()
 
     default int slowSignupAttempts() {
@@ -14,5 +15,9 @@ interface SlowServerConfig {
 
     default int slowOrderingAttempts() {
         isSlowOrdering() ? Integer.MAX_VALUE : 0
+    }
+
+    default int slowAuthorizationAttempts() {
+        isSlowAuthorization() ? Integer.MAX_VALUE : 0
     }
 }

--- a/acme/src/test/groovy/io/micronaut/mock/slow/SlowServerConfig.groovy
+++ b/acme/src/test/groovy/io/micronaut/mock/slow/SlowServerConfig.groovy
@@ -7,4 +7,12 @@ interface SlowServerConfig {
     boolean isSlowAuthorization()
     boolean isSlowOrdering()
     Duration getDuration()
+
+    default int slowSignupAttempts() {
+        isSlowSignup() ? Integer.MAX_VALUE : 0
+    }
+
+    default int slowOrderingAttempts() {
+        isSlowOrdering() ? Integer.MAX_VALUE : 0
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ micronaut-serde = "3.0.0-M8"
 micronaut-validation = "5.0.0-M2"
 micronaut-gradle-plugin = "4.6.2"
 bouncycastle = "1.84"
+netty = "4.2.13.Final"
 [libraries]
 # Core
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
@@ -17,6 +18,7 @@ micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-
 
 graal = { module = "org.graalvm.nativeimage:svm" }
 netty-tcnative-boringssl-static = { module = 'io.netty:netty-tcnative-boringssl-static' }
+netty-codec-http = { module = 'io.netty:netty-codec-http', version.ref = 'netty' }
 bouncycastle-bcpkix = { module = 'org.bouncycastle:bcpkix-jdk18on', version.ref = 'bouncycastle' }
 bouncycastle-bcprov = { module = 'org.bouncycastle:bcprov-jdk18on', version.ref = 'bouncycastle' }
 

--- a/src/main/docs/guide/configuration.adoc
+++ b/src/main/docs/guide/configuration.adoc
@@ -43,12 +43,18 @@ acme:
     order:
         pause: 3s // <13>
         refresh-attempts: 10 // <14>
+    request-retry:
+        attempts: 3 // <15>
+        delay: 1s // <16>
+        max-delay: 5s // <17>
+        multiplier: 1.5 // <18>
+        jitter: 0.1 // <19>
     auth:
-        pause: 1m // <15>
-        refresh-attempts: 10 // <16>
-    renew-within: 30 // <17>
-    challenge-type: tls // <18>
-    timeout: 10s //<19>
+        pause: 1m // <20>
+        refresh-attempts: 10 // <21>
+    renew-within: 30 // <22>
+    challenge-type: tls // <23>
+    timeout: 10s //<24>
 ----
 <1> Set the http port for micronaut. If using http challenge-type this must be set to port 80, unless using a load balancer or some other proxy as Let's Encrypt for example only sends request to port 80.
 <2> Enables dual port mode that allows for both http and https to be bound. Default is `false`
@@ -64,8 +70,13 @@ acme:
 <12> Url of the ACME server (ex. acme://letsencrypt.org/staging)
 <13> Time to wait in between polling order status of the ACME server. Default is `3 seconds`
 <14> Number of times to poll an order status of the ACME server. Default is `10`
-<15> Time to wait in between polling authorization status of the ACME server. Default is `3 seconds`
-<16> Number of times to poll an authorization status of the ACME server. Default is `10`
-<17> Number of days before the process will start to try to refresh the certificate from the ACME provider. Default is `30 days`
-<18> The challenge type you would like to use. Default is `tls`. Possible options : http, tls, dns
-<19> Sets the connection/read timeout when making http calls to the ACME server. Default comes from here https://shredzone.org/maven/acme4j/acme4j-client/apidocs/src-html/org/shredzone/acme4j/connector/NetworkSettings.html#line.61
+<15> Number of times to retry login and new order requests after network failures. Default is `3`
+<16> Delay between login and new order request retries. Default is `1 second`
+<17> Maximum overall delay for login and new order request retries. Default is unset
+<18> Delay multiplier for login and new order request retries. Default is `1.0`
+<19> Jitter factor for login and new order request retries. Default is `0.0`
+<20> Time to wait in between polling authorization status of the ACME server. Default is `3 seconds`
+<21> Number of times to poll an authorization status of the ACME server. Default is `10`
+<22> Number of days before the process will start to try to refresh the certificate from the ACME provider. Default is `30 days`
+<23> The challenge type you would like to use. Default is `tls`. Possible options : http, tls, dns
+<24> Sets the connection/read timeout when making http calls to the ACME server. Default comes from here https://shredzone.org/maven/acme4j/acme4j-client/apidocs/src-html/org/shredzone/acme4j/connector/NetworkSettings.html#line.61


### PR DESCRIPTION
Summary:
- Adds configurable retry policy for ACME login and new order requests.
- Retries ACME network failures while preserving non-network ACME exceptions.
- Documents request-retry options and covers transient login/order timeouts.

Testing:
- ./gradlew :micronaut-acme:test --tests io.micronaut.acme.AcmeCertRefresherTaskSetsTimeoutSpec -q

Resolves https://github.com/micronaut-projects/micronaut-acme/issues/15
