### PR TITLE
Support standard SSL options for ACME contexts

### DIFF
--- a/acme/src/main/java/io/micronaut/acme/ssl/AcmeSSLContextBuilder.java
+++ b/acme/src/main/java/io/micronaut/acme/ssl/AcmeSSLContextBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,11 @@ import io.micronaut.acme.events.CertificateEvent;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.http.server.netty.ssl.CertificateProvidedSslBuilder;
 import io.micronaut.http.server.netty.ssl.ServerSslBuilder;
+import io.micronaut.http.ssl.ClientAuthentication;
 import io.micronaut.http.ssl.ServerSslConfiguration;
 import io.micronaut.runtime.event.annotation.EventListener;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
@@ -31,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLException;
+import java.util.Arrays;
 import java.util.Optional;
 
 /**
@@ -66,8 +69,8 @@ public class AcmeSSLContextBuilder implements ServerSslBuilder {
             }
             if (certificateEvent.isValidationCert()) {
                 SslProvider provider = SslProvider.isAlpnSupported(SslProvider.OPENSSL) ? SslProvider.OPENSSL : SslProvider.JDK;
-                SslContext sslContext = SslContextBuilder
-                        .forServer(certificateEvent.getDomainKeyPair().getPrivate(), certificateEvent.getCert())
+                SslContext sslContext = applyProtocolsAndCiphers(SslContextBuilder
+                        .forServer(certificateEvent.getDomainKeyPair().getPrivate(), certificateEvent.getCert()))
                         .sslProvider(provider)
                         .applicationProtocolConfig(new ApplicationProtocolConfig(
                                 ApplicationProtocolConfig.Protocol.ALPN,
@@ -79,8 +82,8 @@ public class AcmeSSLContextBuilder implements ServerSslBuilder {
                         .build();
                 delegatedSslContext.setNewSslContext(sslContext);
             } else {
-                SslContext sslContext = SslContextBuilder
-                        .forServer(certificateEvent.getDomainKeyPair().getPrivate(), certificateEvent.getFullCertificateChain())
+                SslContext sslContext = applySslConfiguration(SslContextBuilder
+                        .forServer(certificateEvent.getDomainKeyPair().getPrivate(), certificateEvent.getFullCertificateChain()))
                         .build();
                 delegatedSslContext.setNewSslContext(sslContext);
             }
@@ -104,5 +107,27 @@ public class AcmeSSLContextBuilder implements ServerSslBuilder {
     @Override
     public Optional<SslContext> build() {
         return Optional.of(delegatedSslContext);
+    }
+
+    private SslContextBuilder applySslConfiguration(SslContextBuilder builder) {
+        applyProtocolsAndCiphers(builder);
+        applyClientAuthentication(builder);
+        return builder;
+    }
+
+    private SslContextBuilder applyProtocolsAndCiphers(SslContextBuilder builder) {
+        ssl.getProtocols().ifPresent(builder::protocols);
+        ssl.getCiphers().ifPresent(ciphers -> builder.ciphers(Arrays.asList(ciphers)));
+        return builder;
+    }
+
+    private void applyClientAuthentication(SslContextBuilder builder) {
+        ssl.getClientAuthentication().ifPresent(clientAuthentication -> {
+            if (clientAuthentication == ClientAuthentication.NEED) {
+                builder.clientAuth(ClientAuth.REQUIRE);
+            } else if (clientAuthentication == ClientAuthentication.WANT) {
+                builder.clientAuth(ClientAuth.OPTIONAL);
+            }
+        });
     }
 }

--- a/acme/src/test/groovy/io/micronaut/acme/ssl/AcmeSSLContextBuilderSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/ssl/AcmeSSLContextBuilderSpec.groovy
@@ -1,0 +1,61 @@
+package io.micronaut.acme.ssl
+
+import io.micronaut.acme.events.CertificateEvent
+import io.micronaut.http.ssl.ClientAuthentication
+import io.micronaut.http.ssl.ServerSslConfiguration
+import io.netty.buffer.ByteBufAllocator
+import io.netty.handler.ssl.util.SelfSignedCertificate
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import javax.net.ssl.SSLContext
+import java.security.KeyPair
+
+class AcmeSSLContextBuilderSpec extends Specification {
+
+    @Unroll
+    def "applies standard ssl options with #clientAuthentication client authentication to #certificateType certificate context"() {
+        given:
+            def certificate = new SelfSignedCertificate("localhost")
+            def keyPair = new KeyPair(certificate.cert().publicKey, certificate.key())
+            def cipher = tls12Cipher()
+            assert cipher != null
+            def ssl = new ServerSslConfiguration()
+            ssl.setProtocols(["TLSv1.2"] as String[])
+            ssl.setCiphers([cipher] as String[])
+            if (clientAuthentication != null) {
+                ssl.setClientAuthentication(clientAuthentication)
+            }
+            def builder = new AcmeSSLContextBuilder(ssl)
+            def context = builder.build().get()
+
+        when:
+            builder.onNewCertificate(new CertificateEvent(keyPair, validationCertificate, certificate.cert()))
+            def engine = context.newEngine(ByteBufAllocator.DEFAULT)
+
+        then:
+            engine.enabledProtocols as List == ["TLSv1.2"]
+            engine.enabledCipherSuites as List == [cipher]
+            engine.needClientAuth == needClientAuth
+            engine.wantClientAuth == wantClientAuth
+
+        cleanup:
+            certificate?.delete()
+
+        where:
+            validationCertificate | clientAuthentication       | needClientAuth | wantClientAuth
+            false                 | ClientAuthentication.NEED | true           | false
+            false                 | ClientAuthentication.WANT | false          | true
+            false                 | null                      | false          | false
+            true                  | ClientAuthentication.NEED | false          | false
+            true                  | ClientAuthentication.WANT | false          | false
+            true                  | null                      | false          | false
+
+            certificateType = validationCertificate ? "validation" : "issued"
+    }
+
+    private static String tls12Cipher() {
+        SSLContext.default.defaultSSLParameters.cipherSuites.find { it == "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" }
+                ?: SSLContext.default.defaultSSLParameters.cipherSuites.find { it.startsWith("TLS_ECDHE_RSA_") && it.contains("_GCM_") }
+    }
+}


### PR DESCRIPTION
## Summary

- Apply configured server SSL protocols and ciphers to ACME certificate contexts.
- Apply configured client authentication only to issued certificate contexts, leaving TLS-ALPN validation contexts unauthenticated.
- Add coverage for NEED, WANT, and unset client authentication on issued and validation contexts.

## Verification

- ./gradlew :micronaut-acme:test --tests io.micronaut.acme.ssl.AcmeSSLContextBuilderSpec

Resolves https://github.com/micronaut-projects/micronaut-acme/issues/10
