### PR TITLE
Delay DNS challenge trigger until auth pause elapses

### DIFF
--- a/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
+++ b/acme/src/main/java/io/micronaut/acme/services/AcmeService.java
@@ -65,6 +65,7 @@ import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -453,7 +454,7 @@ public class AcmeService {
     @SuppressWarnings("java:S3776")
     private void doChallengeAuthorization(Authorization auth, Challenge challenge) throws AcmeException {
         AtomicInteger authRetryAttempts = new AtomicInteger(acmeConfiguration.getAuth().getRefreshAttempts());
-        challenge.trigger();
+        triggerChallenge(challenge);
         SelfCancellable authStatusPoll = new SelfCancellable() {
             @Override
             public void run() {
@@ -505,6 +506,22 @@ public class AcmeService {
             //cancel is used in happy path so, ignoring this
         } finally {
             doChallengeSpecificCleanup(auth, challenge);
+        }
+    }
+
+    final void triggerChallenge(Challenge challenge) throws AcmeException {
+        waitForDnsChallengePropagation(challenge);
+        challenge.trigger();
+    }
+
+    private void waitForDnsChallengePropagation(Challenge challenge) throws AcmeException {
+        if (challenge instanceof Dns01Challenge && !authPause.isZero() && !authPause.isNegative()) {
+            try {
+                TimeUnit.NANOSECONDS.sleep(authPause.toNanos());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AcmeException("ACME certificate challenge initial DNS delay interrupted", e);
+            }
         }
     }
 

--- a/acme/src/test/groovy/io/micronaut/acme/services/AcmeServiceSpec.groovy
+++ b/acme/src/test/groovy/io/micronaut/acme/services/AcmeServiceSpec.groovy
@@ -1,0 +1,61 @@
+package io.micronaut.acme.services
+
+import io.micronaut.acme.AcmeConfiguration
+import io.micronaut.acme.challenge.dns.DnsChallengeSolver
+import io.micronaut.context.event.ApplicationEventPublisher
+import io.micronaut.core.io.ResourceResolver
+import io.micronaut.scheduling.TaskScheduler
+import org.shredzone.acme4j.challenge.Dns01Challenge
+import org.shredzone.acme4j.challenge.Http01Challenge
+import spock.lang.Specification
+
+import java.time.Duration
+
+class AcmeServiceSpec extends Specification {
+
+    void "waits auth pause before triggering dns challenge"() {
+        given:
+            Duration pause = Duration.ofMillis(50)
+            AcmeService acmeService = acmeService(pause)
+            Dns01Challenge challenge = Mock()
+            long startedAt
+            long triggeredAt
+
+        when:
+            startedAt = System.nanoTime()
+            acmeService.triggerChallenge(challenge)
+
+        then:
+            1 * challenge.trigger() >> { triggeredAt = System.nanoTime() }
+            triggeredAt - startedAt >= pause.toNanos()
+    }
+
+    void "does not wait auth pause before triggering other challenge types"() {
+        given:
+            Duration pause = Duration.ofSeconds(5)
+            AcmeService acmeService = acmeService(pause)
+            Http01Challenge challenge = Mock()
+            long startedAt
+            long triggeredAt
+
+        when:
+            startedAt = System.nanoTime()
+            acmeService.triggerChallenge(challenge)
+
+        then:
+            1 * challenge.trigger() >> { triggeredAt = System.nanoTime() }
+            triggeredAt - startedAt < Duration.ofSeconds(1).toNanos()
+    }
+
+    private AcmeService acmeService(Duration authPause) {
+        AcmeConfiguration acmeConfiguration = new AcmeConfiguration()
+        acmeConfiguration.auth.pause = authPause
+        new AcmeService(
+                Mock(ApplicationEventPublisher),
+                acmeConfiguration,
+                Mock(ResourceResolver),
+                Mock(TaskScheduler),
+                Mock(DnsChallengeSolver)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- wait for the configured authorization pause before triggering DNS-01 challenges
- keep HTTP-01 and TLS-ALPN-01 challenge triggering immediate
- add focused unit coverage for DNS versus non-DNS trigger timing

## Tests
- `./gradlew :micronaut-acme:test --tests io.micronaut.acme.services.AcmeServiceSpec`
- `./gradlew :micronaut-acme:spotlessCheck :micronaut-acme:checkstyleMain :micronaut-acme:checkstyleTest`

Resolves https://github.com/micronaut-projects/micronaut-acme/issues/74
